### PR TITLE
[Feature/#42] MartSearch api 재연결 및 dialog 개선

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-05-28T05:46:57.822412100Z">
+        <DropdownSelection timestamp="2025-06-17T05:05:35.280412300Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="PhysicalDevice" identifier="serial=R3CX20PCWHP" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\kimta\.android\avd\Pixel_7_API_34.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-06-17T05:05:35.280412300Z">
+        <DropdownSelection timestamp="2025-06-17T11:17:40.389405100Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\kimta\.android\avd\Pixel_7_API_34.avd" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=R39M200LRZV" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/data/src/main/java/project/graduation/crowd_sourcing/data/repository/MartSearchRepositoryImpl.kt
+++ b/data/src/main/java/project/graduation/crowd_sourcing/data/repository/MartSearchRepositoryImpl.kt
@@ -2,6 +2,7 @@ package project.graduation.crowd_sourcing.data.repository
 
 import project.graduation.crowd_sourcing.data.service.MartSearchService
 import project.graduation.crowd_sourcing.domain.model.entity.martsearch.MartEntity
+import project.graduation.crowd_sourcing.domain.model.entity.martsearch.MartWorkEntity
 import project.graduation.crowd_sourcing.domain.repository.MartSearchRepository
 import javax.inject.Inject
 
@@ -50,6 +51,23 @@ class MartSearchRepositoryImpl @Inject constructor(
                 sigungu = martDto.sigungu,
                 dong = martDto.dong,
                 existCommission = martDto.existCommission
+            )
+        }
+    }
+
+    override suspend fun searchWorkByMartName(martName : String): List<MartWorkEntity>{
+        return martSearchService.getSearchWorkByMartName(martName).data.map { martWorkDto ->
+            MartWorkEntity(
+                id = martWorkDto.id,
+                work = martWorkDto.work,
+                workCount = martWorkDto.workCount,
+                workpoint = martWorkDto.workpoint,
+                workhour = martWorkDto.workhour,
+                category = martWorkDto.category,
+                item = martWorkDto.item,
+                workDate = martWorkDto.workDate,
+                itemPrice = martWorkDto.itemPrice,
+                workStatus = martWorkDto.workStatus
             )
         }
     }

--- a/data/src/main/java/project/graduation/crowd_sourcing/data/response/martsearch/SearchMartResponse.kt
+++ b/data/src/main/java/project/graduation/crowd_sourcing/data/response/martsearch/SearchMartResponse.kt
@@ -1,5 +1,8 @@
 package project.graduation.crowd_sourcing.data.response.martsearch
 
+import project.graduation.crowd_sourcing.domain.model.WorkStatus
+import java.time.LocalDateTime
+
 data class ApiResponseDtoListMartDto (
     val status: Int,
     val message: String,
@@ -17,9 +20,22 @@ data class MartDto(
     val existCommission: Int
 )
 
-data class MartDto1(
-    val sigungu: String,
-    val martName: String,
-    val lat: Double,
-    val lng: Double
+data class ApiResponseDtoListMartWorkDto(
+    val status: Int,
+    val message: String,
+    val data: List<MartWorkDto>
 )
+
+data class MartWorkDto(
+    val id : Int,
+    val work : String,
+    val workCount : Int,
+    val workpoint : Int,
+    val workhour : Int,
+    val category: String,
+    val item : String,
+    val workDate : LocalDateTime,
+    val itemPrice : Int,
+    val workStatus: WorkStatus
+)
+

--- a/data/src/main/java/project/graduation/crowd_sourcing/data/service/MartSearchService.kt
+++ b/data/src/main/java/project/graduation/crowd_sourcing/data/service/MartSearchService.kt
@@ -1,6 +1,7 @@
 package project.graduation.crowd_sourcing.data.service
 
 import project.graduation.crowd_sourcing.data.response.martsearch.ApiResponseDtoListMartDto
+import project.graduation.crowd_sourcing.data.response.martsearch.ApiResponseDtoListMartWorkDto
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Query
@@ -24,4 +25,9 @@ interface MartSearchService {
         @Query("keyword") keyword : String,
         @Query("radiusKm") radius: Double,
     ) : ApiResponseDtoListMartDto
+
+    @GET("/api/v1/marts/search/martlist")
+    suspend fun getSearchWorkByMartName(
+        @Query("martName") martName : String
+    ) : ApiResponseDtoListMartWorkDto
 }

--- a/domain/src/main/java/project/graduation/crowd_sourcing/domain/model/entity/martsearch/MartWorkEntity.kt
+++ b/domain/src/main/java/project/graduation/crowd_sourcing/domain/model/entity/martsearch/MartWorkEntity.kt
@@ -1,0 +1,17 @@
+package project.graduation.crowd_sourcing.domain.model.entity.martsearch
+
+import project.graduation.crowd_sourcing.domain.model.WorkStatus
+import java.time.LocalDateTime
+
+data class MartWorkEntity(
+    val id : Int,
+    val work : String,
+    val workCount : Int,
+    val workpoint : Int,
+    val workhour : Int,
+    val category: String,
+    val item : String,
+    val workDate : LocalDateTime,
+    val itemPrice : Int,
+    val workStatus: WorkStatus
+)

--- a/domain/src/main/java/project/graduation/crowd_sourcing/domain/repository/MartSearchRepository.kt
+++ b/domain/src/main/java/project/graduation/crowd_sourcing/domain/repository/MartSearchRepository.kt
@@ -1,9 +1,11 @@
 package project.graduation.crowd_sourcing.domain.repository
 
 import project.graduation.crowd_sourcing.domain.model.entity.martsearch.MartEntity
+import project.graduation.crowd_sourcing.domain.model.entity.martsearch.MartWorkEntity
 
 interface MartSearchRepository {
     suspend fun searchMartByZipcode(zipcode: String, radius: Int): List<MartEntity>
     suspend fun searchMartByLocation(lat: Double, lng: Double, radius: Double): List<MartEntity>
     suspend fun searchMartByKeyword(keyword: String, radius: Double): List<MartEntity>
+    suspend fun searchWorkByMartName(martName: String): List<MartWorkEntity>
 }

--- a/domain/src/main/java/project/graduation/crowd_sourcing/domain/usecase/MartSearchUseCase.kt
+++ b/domain/src/main/java/project/graduation/crowd_sourcing/domain/usecase/MartSearchUseCase.kt
@@ -1,6 +1,7 @@
 package project.graduation.crowd_sourcing.domain.usecase
 
 import project.graduation.crowd_sourcing.domain.model.entity.martsearch.MartEntity
+import project.graduation.crowd_sourcing.domain.model.entity.martsearch.MartWorkEntity
 import project.graduation.crowd_sourcing.domain.repository.MartSearchRepository
 import javax.inject.Inject
 
@@ -17,5 +18,9 @@ class MartSearchUseCase @Inject constructor(
 
     suspend fun searchMartByKeyword(keyword: String, radius: Double): List<MartEntity> {
         return martSearchRepository.searchMartByKeyword(keyword, radius)
+    }
+
+    suspend fun searchWorkByMartName(martName: String): List<MartWorkEntity> {
+        return martSearchRepository.searchWorkByMartName(martName)
     }
 } 

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/HomeViewModel.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/HomeViewModel.kt
@@ -511,17 +511,45 @@ class HomeViewModel @Inject constructor(
      * @param mart 클릭된 마트 정보
      */
     fun onMartClicked(mart: MartEntity) {
-        // 더미 데이터로 해당 마트의 의뢰 목록 생성
-        val martRequests = generateMartRequestsForDemo(mart)
-        
-        _uiState.update { currentState ->
-            when (currentState) {
-                is HomeUiState.Success -> currentState.copy(
-                    selectedMart = mart,
-                    selectedMartRequests = martRequests,
-                    isMartRequestDialogVisible = true
-                )
-                else -> currentState
+        viewModelScope.launch {
+            try {
+                // 실제 usecase를 사용하여 마트 의뢰 정보 조회
+                val martWorkEntities = martSearchUseCase.searchWorkByMartName(mart.martName)
+                
+                // MartWorkEntity를 Request로 변환
+                val martRequests = martWorkEntities.map { workEntity ->
+                    Request(
+                        id = workEntity.id.toString(),
+                        title = "${mart.martName} - ${workEntity.work}",
+                        location = Location(mart.latitude, mart.longitude),
+                        place = mart.martName,
+                        reward = workEntity.workpoint
+                    )
+                }
+                
+                _uiState.update { currentState ->
+                    when (currentState) {
+                        is HomeUiState.Success -> currentState.copy(
+                            selectedMart = mart,
+                            selectedMartRequests = martRequests,
+                            isMartRequestDialogVisible = true
+                        )
+                        else -> currentState
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "마트 의뢰 조회 실패: ${e.message}", e)
+                // 에러 발생 시 빈 목록으로 처리
+                _uiState.update { currentState ->
+                    when (currentState) {
+                        is HomeUiState.Success -> currentState.copy(
+                            selectedMart = mart,
+                            selectedMartRequests = emptyList(),
+                            isMartRequestDialogVisible = true
+                        )
+                        else -> currentState
+                    }
+                }
             }
         }
     }
@@ -542,95 +570,5 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    /**
-     * 데모용 마트 의뢰 데이터 생성
-     * TODO: 실제 API 연결 시 제거하고 실제 UseCase로 교체
-     */
-    private fun generateMartRequestsForDemo(mart: MartEntity): List<Request> {
-        // 마트 이름에 따라 다른 더미 데이터 생성
-        return when {
-            mart.martName.contains("이마트") || mart.martName.contains("E-MART") -> {
-                listOf(
-                    Request(
-                        id = "mart_${mart.martId}_1",
-                        title = "${mart.martName} - 바나나 가격 확인",
-                        location = Location(mart.latitude, mart.longitude),
-                        place = mart.martName,
-                        reward = 3000
-                    ),
-                    Request(
-                        id = "mart_${mart.martId}_2",
-                        title = "${mart.martName} - 딸기 재고 확인",
-                        location = Location(mart.latitude, mart.longitude),
-                        place = mart.martName,
-                        reward = 5000
-                    )
-                )
-            }
-            mart.martName.contains("롯데마트") || mart.martName.contains("LOTTE") -> {
-                listOf(
-                    Request(
-                        id = "mart_${mart.martId}_1",
-                        title = "${mart.martName} - 사과 가격 조사",
-                        location = Location(mart.latitude, mart.longitude),
-                        place = mart.martName,
-                        reward = 4000
-                    )
-                )
-            }
-            mart.martName.contains("홈플러스") -> {
-                listOf(
-                    Request(
-                        id = "mart_${mart.martId}_1",
-                        title = "${mart.martName} - 오렌지 할인 여부 확인",
-                        location = Location(mart.latitude, mart.longitude),
-                        place = mart.martName,
-                        reward = 2500
-                    ),
-                    Request(
-                        id = "mart_${mart.martId}_2",
-                        title = "${mart.martName} - 포도 품질 체크",
-                        location = Location(mart.latitude, mart.longitude),
-                        place = mart.martName,
-                        reward = 3500
-                    ),
-                    Request(
-                        id = "mart_${mart.martId}_3",
-                        title = "${mart.martName} - 신선식품 진열 상태 확인",
-                        location = Location(mart.latitude, mart.longitude),
-                        place = mart.martName,
-                        reward = 6000
-                    )
-                )
-            }
-            mart.martName.contains("GS25") || mart.martName.contains("CU") || mart.martName.contains("세븐일레븐") -> {
-                listOf(
-                    Request(
-                        id = "mart_${mart.martId}_1",
-                        title = "${mart.martName} - 음료수 가격 확인",
-                        location = Location(mart.latitude, mart.longitude),
-                        place = mart.martName,
-                        reward = 1500
-                    )
-                )
-            }
-            else -> {
-                // 일반 마트나 기타 상점의 경우
-                if ((0..10).random() > 3) { // 70% 확률로 의뢰 있음
-                    val requestCount = (1..2).random()
-                    (1..requestCount).map { index ->
-                        Request(
-                            id = "mart_${mart.martId}_$index",
-                            title = "${mart.martName} - ${listOf("가격 조사", "재고 확인", "품질 체크", "할인 여부 확인").random()}",
-                            location = Location(mart.latitude, mart.longitude),
-                            place = mart.martName,
-                            reward = (1500..6000).random()
-                        )
-                    }
-                } else {
-                    emptyList() // 30% 확률로 의뢰 없음
-                }
-            }
-        }
-    }
+
 } 

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/component/MartRequestDialog.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/component/MartRequestDialog.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
@@ -209,12 +210,16 @@ private fun MartRequestItem(request: Request) {
                     Text(
                         text = request.title,
                         style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Medium
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                     Text(
                         text = request.place,
                         style = MaterialTheme.typography.bodySmall,
-                        color = Color.Gray
+                        color = Color.Gray,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                 }
             }

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/component/SearchResultDialog.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/component/SearchResultDialog.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
@@ -176,7 +177,9 @@ private fun DialogItem(request: Request) {
             
             Text(
                 text = request.title,
-                style = MaterialTheme.typography.bodyLarge
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
         }
         
@@ -232,12 +235,16 @@ private fun MartDialogItem(
                 Text(
                     text = mart.martName,
                     style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
                 Text(
                     text = "${mart.sido} ${mart.sigungu ?: ""} ${mart.dong ?: ""}".trim(),
                     style = MaterialTheme.typography.bodySmall,
-                    color = Color.Gray
+                    color = Color.Gray,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
             }
         }


### PR DESCRIPTION
## *📌 Issue*

## ⛳️ Work Description

### 📌 MartSearch API 연동
- 마트 이름 기반으로 해당 마트의 의뢰를 검색하는 `MartSearch API` 연결

### 🧩 UseCase → UI 연결
- 마트 의뢰 목록 반환 UseCase를 **실제 UI와 연결**
  - 홈 화면 **지도 핀 클릭 시** 해당 마트의 의뢰 조회
  - 홈 화면 **검색 결과에서 마트 클릭 시** 해당 마트의 의뢰 조회

### 🛠️ Dialog 텍스트 표시 개선
- 다이얼로그 내 텍스트가 여러 줄일 경우 각 항목 간 간격이 들쭉날쭉했던 문제 수정
  - **한 줄로만 표시되도록 설정하여** UI 정렬 개선

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->
- 실제 있는 마트의 의뢰만 표사(usecase사용)
![image](https://github.com/user-attachments/assets/bdec83fb-94fc-483e-8383-b4536fba01b0)

- 마트의 작업 제목이 길 경우 여러줄로 표시되던걸 한줄에 출력하고, 뒤에 "..."로 줄여서 표현
![image](https://github.com/user-attachments/assets/d567c582-bf27-497c-b9dc-5b6f7dc7fe1c)


## *📢 To Reviewers*
- 혹시 추가 변경사항 필요한 점 있으시면 연락부탁드립니다

<!-- PR 제목 형식: [FEATURE/#이슈번호] 작업 주제 -->
