### PR TITLE
[Feature/#50] 작업 수락 api 및 화면 구현, 검색화면 결과 로직 수정

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-06-22T15:16:36.192056400Z">
+        <DropdownSelection timestamp="2025-06-22T22:06:11.897765200Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\kimta\.android\avd\Pixel_77.avd" />

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-06-17T12:15:08.349093700Z">
+        <DropdownSelection timestamp="2025-06-22T15:16:36.192056400Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\kimta\.android\avd\Pixel_7_API_34.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\kimta\.android\avd\Pixel_77.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-06-17T11:17:40.389405100Z">
+        <DropdownSelection timestamp="2025-06-17T12:15:08.349093700Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="PhysicalDevice" identifier="serial=R39M200LRZV" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\kimta\.android\avd\Pixel_7_API_34.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/data/src/main/java/project/graduation/crowd_sourcing/data/di/BindModule.kt
+++ b/data/src/main/java/project/graduation/crowd_sourcing/data/di/BindModule.kt
@@ -4,6 +4,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import project.graduation.crowd_sourcing.data.repository.AlarmRepositoryImpl
 import project.graduation.crowd_sourcing.data.repository.FcmRepositoryImpl
 import project.graduation.crowd_sourcing.data.repository.LocationRepositoryImpl
 import project.graduation.crowd_sourcing.data.repository.LoginRepositoryImpl
@@ -15,6 +16,7 @@ import project.graduation.crowd_sourcing.data.repository.StatisticsRepositoryImp
 import project.graduation.crowd_sourcing.data.repository.UserPointRepositoryImpl
 import project.graduation.crowd_sourcing.data.repository.WorkRepositoryImpl
 import project.graduation.crowd_sourcing.data.repository.WorkerRepositoryImpl
+import project.graduation.crowd_sourcing.domain.repository.AlarmRepository
 import project.graduation.crowd_sourcing.domain.repository.FcmRepository
 import project.graduation.crowd_sourcing.domain.repository.LocationRepository
 import project.graduation.crowd_sourcing.domain.repository.LoginRepository
@@ -88,5 +90,10 @@ abstract class BindModule {
     abstract fun bindLocationRepository(
         repository: LocationRepositoryImpl
     ): LocationRepository
+
+    @Binds
+    abstract fun bindAlarmRepository(
+        repository: AlarmRepositoryImpl
+    ): AlarmRepository
 
 }

--- a/data/src/main/java/project/graduation/crowd_sourcing/data/di/NetworkModule.kt
+++ b/data/src/main/java/project/graduation/crowd_sourcing/data/di/NetworkModule.kt
@@ -25,6 +25,7 @@ import project.graduation.crowd_sourcing.data.service.StatisticsService
 import project.graduation.crowd_sourcing.data.service.UserPointService
 import project.graduation.crowd_sourcing.data.service.WorkService
 import project.graduation.crowd_sourcing.data.service.WorkerService
+import project.graduation.crowd_sourcing.data.service.alarm.AlarmService
 import project.graduation.crowd_sourcing.data.service.alarm.FcmService
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -147,6 +148,9 @@ class NetworkModule {
         provideService(retrofit)
 
     @Provides fun provideFcmService(retrofit: Retrofit): FcmService =
+        provideService(retrofit)
+
+    @Provides fun provideAlarmService(retrofit: Retrofit): AlarmService =
         provideService(retrofit)
 
     @Provides fun provideLocationService(retrofit: Retrofit): LocationService =

--- a/data/src/main/java/project/graduation/crowd_sourcing/data/repository/AlarmRepositoryImpl.kt
+++ b/data/src/main/java/project/graduation/crowd_sourcing/data/repository/AlarmRepositoryImpl.kt
@@ -1,0 +1,49 @@
+package project.graduation.crowd_sourcing.data.repository
+
+import project.graduation.crowd_sourcing.data.service.alarm.AlarmService
+import project.graduation.crowd_sourcing.domain.repository.AlarmRepository
+import javax.inject.Inject
+
+class AlarmRepositoryImpl @Inject constructor(
+    private val alarmService: AlarmService
+) : AlarmRepository {
+
+    override suspend fun postCancel(workId: Int, memberId: Int): Result<String> {
+        return try {
+            val response = alarmService.postCancel(workId, memberId)
+            if (response.isSuccessful) {
+                Result.success(response.body() ?: "작업이 취소되었습니다.")
+            } else {
+                Result.failure(Exception("작업 취소 실패: ${response.code()}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun postAccept(workId: Int, memberId: Int): Result<String> {
+        return try {
+            val response = alarmService.postAccept(workId, memberId)
+            if (response.isSuccessful) {
+                Result.success(response.body() ?: "작업이 수락되었습니다.")
+            } else {
+                Result.failure(Exception("작업 수락 실패: ${response.code()}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun getSendNotification(latitude: Double, longitude: Double): Result<String> {
+        return try {
+            val response = alarmService.getSendNotification(latitude, longitude)
+            if (response.isSuccessful) {
+                Result.success(response.body() ?: "알림이 전송되었습니다.")
+            } else {
+                Result.failure(Exception("알림 전송 실패: ${response.code()}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+} 

--- a/data/src/main/java/project/graduation/crowd_sourcing/data/repository/AlarmRepositoryImpl.kt
+++ b/data/src/main/java/project/graduation/crowd_sourcing/data/repository/AlarmRepositoryImpl.kt
@@ -12,7 +12,7 @@ class AlarmRepositoryImpl @Inject constructor(
         return try {
             val response = alarmService.postCancel(workId, memberId)
             if (response.isSuccessful) {
-                Result.success(response.body() ?: "작업이 취소되었습니다.")
+                Result.success(response.body()?.string() ?: "작업이 취소되었습니다.")
             } else {
                 Result.failure(Exception("작업 취소 실패: ${response.code()}"))
             }
@@ -23,13 +23,22 @@ class AlarmRepositoryImpl @Inject constructor(
 
     override suspend fun postAccept(workId: Int, memberId: Int): Result<String> {
         return try {
+            android.util.Log.d("AlarmRepository", "postAccept 호출: workId=$workId, memberId=$memberId")
             val response = alarmService.postAccept(workId, memberId)
+            android.util.Log.d("AlarmRepository", "응답 코드: ${response.code()}")
+            android.util.Log.d("AlarmRepository", "응답 성공 여부: ${response.isSuccessful}")
+            
             if (response.isSuccessful) {
-                Result.success(response.body() ?: "작업이 수락되었습니다.")
+                val resultMessage = response.body()?.string() ?: "작업이 수락되었습니다."
+                android.util.Log.d("AlarmRepository", "성공 처리: $resultMessage")
+                Result.success(resultMessage)
             } else {
-                Result.failure(Exception("작업 수락 실패: ${response.code()}"))
+                val errorMessage = "작업 수락 실패: ${response.code()}"
+                android.util.Log.e("AlarmRepository", errorMessage)
+                Result.failure(Exception(errorMessage))
             }
         } catch (e: Exception) {
+            android.util.Log.e("AlarmRepository", "예외 발생: ${e.message}", e)
             Result.failure(e)
         }
     }
@@ -38,7 +47,7 @@ class AlarmRepositoryImpl @Inject constructor(
         return try {
             val response = alarmService.getSendNotification(latitude, longitude)
             if (response.isSuccessful) {
-                Result.success(response.body() ?: "알림이 전송되었습니다.")
+                Result.success(response.body()?.string() ?: "알림이 전송되었습니다.")
             } else {
                 Result.failure(Exception("알림 전송 실패: ${response.code()}"))
             }

--- a/data/src/main/java/project/graduation/crowd_sourcing/data/repository/MartSearchRepositoryImpl.kt
+++ b/data/src/main/java/project/graduation/crowd_sourcing/data/repository/MartSearchRepositoryImpl.kt
@@ -71,4 +71,4 @@ class MartSearchRepositoryImpl @Inject constructor(
             )
         }
     }
-} 
+}

--- a/data/src/main/java/project/graduation/crowd_sourcing/data/repository/SearchRepositoryImpl.kt
+++ b/data/src/main/java/project/graduation/crowd_sourcing/data/repository/SearchRepositoryImpl.kt
@@ -3,6 +3,7 @@ package project.graduation.crowd_sourcing.data.repository
 import android.os.Build
 import androidx.annotation.RequiresApi
 import project.graduation.crowd_sourcing.data.service.SearchService
+import project.graduation.crowd_sourcing.domain.model.entity.search.CommissionDetailEntity
 import project.graduation.crowd_sourcing.domain.model.entity.search.CommissionEntity
 import project.graduation.crowd_sourcing.domain.model.entity.search.SearchHomeEntity
 import project.graduation.crowd_sourcing.domain.repository.SearchRepository
@@ -98,6 +99,34 @@ class SearchRepositoryImpl @Inject constructor(
                 recentKeywords = emptyList(),
                 recommendedKeywords = emptyList()
             )
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    override suspend fun getCommissionDetail(commissionId: Int): CommissionDetailEntity {
+        try {
+            println("DEBUG_REPO: 의뢰 상세 정보 요청 - commissionId: $commissionId")
+            
+            val response = searchService.getCommissionDetail(commissionId)
+            
+            println("DEBUG_REPO: 의뢰 상세 정보 응답 수신 - 상태 코드: ${response.status}, 메시지: ${response.message}")
+            
+            if (response.status == 200) {
+                val commissionDetail = response.data.toDomain()
+                
+                println("DEBUG_REPO: 의뢰 상세 정보 변환 완료 - ID: ${commissionDetail.commissionId}, 제목: ${commissionDetail.commission}")
+                
+                return commissionDetail
+            } else {
+                // 에러 처리
+                println("DEBUG_REPO: 의뢰 상세 정보 API 오류 - 상태 코드: ${response.status}, 메시지: ${response.message}")
+                throw Exception("API Error: ${response.message}")
+            }
+        } catch (e: Exception) {
+            // 네트워크 오류 등의 예외 처리
+            println("DEBUG_REPO: 의뢰 상세 정보 예외 발생 - ${e.javaClass.simpleName}: ${e.message}")
+            e.printStackTrace()
+            throw e
         }
     }
 }

--- a/data/src/main/java/project/graduation/crowd_sourcing/data/repository/SearchRepositoryImpl.kt
+++ b/data/src/main/java/project/graduation/crowd_sourcing/data/repository/SearchRepositoryImpl.kt
@@ -109,19 +109,14 @@ class SearchRepositoryImpl @Inject constructor(
             
             val response = searchService.getCommissionDetail(commissionId)
             
-            println("DEBUG_REPO: 의뢰 상세 정보 응답 수신 - 상태 코드: ${response.status}, 메시지: ${response.message}")
+            println("DEBUG_REPO: 의뢰 상세 정보 응답 수신 성공")
             
-            if (response.status == 200) {
-                val commissionDetail = response.data.toDomain()
-                
-                println("DEBUG_REPO: 의뢰 상세 정보 변환 완료 - ID: ${commissionDetail.commissionId}, 제목: ${commissionDetail.commission}")
-                
-                return commissionDetail
-            } else {
-                // 에러 처리
-                println("DEBUG_REPO: 의뢰 상세 정보 API 오류 - 상태 코드: ${response.status}, 메시지: ${response.message}")
-                throw Exception("API Error: ${response.message}")
-            }
+            val commissionDetail = response.toDomain()
+            
+            println("DEBUG_REPO: 의뢰 상세 정보 변환 완료 - ID: ${commissionDetail.commissionId}, 제목: ${commissionDetail.commission}")
+            
+            return commissionDetail
+            
         } catch (e: Exception) {
             // 네트워크 오류 등의 예외 처리
             println("DEBUG_REPO: 의뢰 상세 정보 예외 발생 - ${e.javaClass.simpleName}: ${e.message}")

--- a/data/src/main/java/project/graduation/crowd_sourcing/data/response/search/CommissionDetailResponse.kt
+++ b/data/src/main/java/project/graduation/crowd_sourcing/data/response/search/CommissionDetailResponse.kt
@@ -1,0 +1,40 @@
+package project.graduation.crowd_sourcing.data.response.search
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import project.graduation.crowd_sourcing.domain.model.entity.search.CommissionDetailEntity
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+data class CommissionDetailDto(
+    val commissionId: Int,
+    val commission: String,
+    val region: String,
+    val martName: String,
+    val category: String,
+    val item: String,
+    val commissionPoint: Int,
+    val commissionCount: Int,
+    val createdAt: String,
+    val expirationDate: String
+) {
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun toDomain(): CommissionDetailEntity {
+        val formatter = DateTimeFormatter.ISO_DATE_TIME
+        val createdAtDateTime = LocalDateTime.parse(createdAt, formatter)
+        val expirationDateTime = LocalDateTime.parse(expirationDate, formatter)
+        
+        return CommissionDetailEntity(
+            commissionId = commissionId,
+            commission = commission,
+            region = region,
+            martName = martName,
+            category = category,
+            item = item,
+            commissionPoint = commissionPoint,
+            commissionCount = commissionCount,
+            createdAt = createdAtDateTime,
+            expirationDate = expirationDateTime
+        )
+    }
+} 

--- a/data/src/main/java/project/graduation/crowd_sourcing/data/response/search/SearchCommissionResponse.kt
+++ b/data/src/main/java/project/graduation/crowd_sourcing/data/response/search/SearchCommissionResponse.kt
@@ -14,6 +14,7 @@ data class SearchCommissionResponse<T> (
 )
 
 data class CommissionDto(
+    val commissionId: Int,
     val commission: String,
     val commissionpoint: Int,
     val deadline: String
@@ -24,6 +25,7 @@ data class CommissionDto(
         val deadlineDateTime = LocalDateTime.parse(deadline, formatter)
         
         return CommissionEntity(
+            commissionId = commissionId,
             commission = commission,
             commissionpoint = commissionpoint,
             deadline = deadlineDateTime

--- a/data/src/main/java/project/graduation/crowd_sourcing/data/service/SearchService.kt
+++ b/data/src/main/java/project/graduation/crowd_sourcing/data/service/SearchService.kt
@@ -24,5 +24,5 @@ interface SearchService {
     @GET("/api/v1/search/detail/{commissionId}")
     suspend fun getCommissionDetail(
         @Path("commissionId") commissionId: Int
-    ): SearchCommissionResponse<CommissionDetailDto>
+    ): CommissionDetailDto
 }

--- a/data/src/main/java/project/graduation/crowd_sourcing/data/service/SearchService.kt
+++ b/data/src/main/java/project/graduation/crowd_sourcing/data/service/SearchService.kt
@@ -1,9 +1,11 @@
 package project.graduation.crowd_sourcing.data.service
 
+import project.graduation.crowd_sourcing.data.response.search.CommissionDetailDto
 import project.graduation.crowd_sourcing.data.response.search.CommissionDto
 import project.graduation.crowd_sourcing.data.response.search.SearchCommissionResponse
 import project.graduation.crowd_sourcing.data.response.search.SearchHomeDto
 import retrofit2.http.GET
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface SearchService {
@@ -18,4 +20,9 @@ interface SearchService {
 
     @GET("/api/v1/search/init")
     suspend fun getSearchHomeInit(): SearchCommissionResponse<SearchHomeDto>
+
+    @GET("/api/v1/search/detail/{commissionId}")
+    suspend fun getCommissionDetail(
+        @Path("commissionId") commissionId: Int
+    ): SearchCommissionResponse<CommissionDetailDto>
 }

--- a/data/src/main/java/project/graduation/crowd_sourcing/data/service/alarm/AlarmService.kt
+++ b/data/src/main/java/project/graduation/crowd_sourcing/data/service/alarm/AlarmService.kt
@@ -8,17 +8,19 @@ import retrofit2.http.Query
 interface AlarmService {
     @POST("/api/v1/marts/cancel")
     suspend fun postCancel(
-        @Query("username") username: String
-    ): Response<Unit>
+        @Query("workId") workId : Int,
+        @Query("memberId") memberId : Int
+    ): Response<String>
 
     @POST("/api/v1/marts/accept")
     suspend fun postAccept(
-        @Query("username") username: String
-    ): Response<Unit>
+        @Query("workId") workId : Int,
+        @Query("memberId") memberId : Int
+    ): Response<String>
 
     @GET("/api/v1/marts/send-notifications")
     suspend fun getSendNotification(
         @Query("latitude") latitude: Double,
         @Query("longitude") longitude: Double
-    ): Response<Unit>
+    ): Response<String>
 }

--- a/data/src/main/java/project/graduation/crowd_sourcing/data/service/alarm/AlarmService.kt
+++ b/data/src/main/java/project/graduation/crowd_sourcing/data/service/alarm/AlarmService.kt
@@ -1,5 +1,6 @@
 package project.graduation.crowd_sourcing.data.service.alarm
 
+import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -10,17 +11,17 @@ interface AlarmService {
     suspend fun postCancel(
         @Query("workId") workId : Int,
         @Query("memberId") memberId : Int
-    ): Response<String>
+    ): Response<ResponseBody>
 
     @POST("/api/v1/marts/accept")
     suspend fun postAccept(
         @Query("workId") workId : Int,
         @Query("memberId") memberId : Int
-    ): Response<String>
+    ): Response<ResponseBody>
 
     @GET("/api/v1/marts/send-notifications")
     suspend fun getSendNotification(
         @Query("latitude") latitude: Double,
         @Query("longitude") longitude: Double
-    ): Response<String>
+    ): Response<ResponseBody>
 }

--- a/domain/src/main/java/project/graduation/crowd_sourcing/domain/model/entity/search/CommissionDetailEntity.kt
+++ b/domain/src/main/java/project/graduation/crowd_sourcing/domain/model/entity/search/CommissionDetailEntity.kt
@@ -1,0 +1,16 @@
+package project.graduation.crowd_sourcing.domain.model.entity.search
+
+import java.time.LocalDateTime
+
+data class CommissionDetailEntity(
+    val commissionId: Int,
+    val commission: String,
+    val region: String,
+    val martName: String,
+    val category: String,
+    val item: String,
+    val commissionPoint: Int,
+    val commissionCount: Int,
+    val createdAt: LocalDateTime,
+    val expirationDate: LocalDateTime
+) 

--- a/domain/src/main/java/project/graduation/crowd_sourcing/domain/model/entity/search/CommissionEntity.kt
+++ b/domain/src/main/java/project/graduation/crowd_sourcing/domain/model/entity/search/CommissionEntity.kt
@@ -3,6 +3,7 @@ package project.graduation.crowd_sourcing.domain.model.entity.search
 import java.time.LocalDateTime
 
 data class CommissionEntity(
+    val commissionId: Int,
     val commission: String,
     val commissionpoint: Int,
     val deadline: LocalDateTime

--- a/domain/src/main/java/project/graduation/crowd_sourcing/domain/repository/AlarmRepository.kt
+++ b/domain/src/main/java/project/graduation/crowd_sourcing/domain/repository/AlarmRepository.kt
@@ -1,0 +1,7 @@
+package project.graduation.crowd_sourcing.domain.repository
+
+interface AlarmRepository {
+    suspend fun postCancel(workId: Int, memberId: Int): Result<String>
+    suspend fun postAccept(workId: Int, memberId: Int): Result<String>
+    suspend fun getSendNotification(latitude: Double, longitude: Double): Result<String>
+} 

--- a/domain/src/main/java/project/graduation/crowd_sourcing/domain/repository/SearchRepository.kt
+++ b/domain/src/main/java/project/graduation/crowd_sourcing/domain/repository/SearchRepository.kt
@@ -1,5 +1,6 @@
 package project.graduation.crowd_sourcing.domain.repository
 
+import project.graduation.crowd_sourcing.domain.model.entity.search.CommissionDetailEntity
 import project.graduation.crowd_sourcing.domain.model.entity.search.CommissionEntity
 import project.graduation.crowd_sourcing.domain.model.entity.search.SearchHomeEntity
 
@@ -13,4 +14,6 @@ interface SearchRepository {
     ): List<CommissionEntity>
     
     suspend fun getSearchHomeInitData(): SearchHomeEntity
+    
+    suspend fun getCommissionDetail(commissionId: Int): CommissionDetailEntity
 }

--- a/domain/src/main/java/project/graduation/crowd_sourcing/domain/usecase/GetCommissionDetailUseCase.kt
+++ b/domain/src/main/java/project/graduation/crowd_sourcing/domain/usecase/GetCommissionDetailUseCase.kt
@@ -1,0 +1,13 @@
+package project.graduation.crowd_sourcing.domain.usecase
+
+import project.graduation.crowd_sourcing.domain.model.entity.search.CommissionDetailEntity
+import project.graduation.crowd_sourcing.domain.repository.SearchRepository
+import javax.inject.Inject
+
+class GetCommissionDetailUseCase @Inject constructor(
+    private val searchRepository: SearchRepository
+) {
+    suspend operator fun invoke(commissionId: Int): CommissionDetailEntity {
+        return searchRepository.getCommissionDetail(commissionId)
+    }
+} 

--- a/domain/src/main/java/project/graduation/crowd_sourcing/domain/usecase/GetSendNotificationUseCase.kt
+++ b/domain/src/main/java/project/graduation/crowd_sourcing/domain/usecase/GetSendNotificationUseCase.kt
@@ -1,0 +1,12 @@
+package project.graduation.crowd_sourcing.domain.usecase
+
+import project.graduation.crowd_sourcing.domain.repository.AlarmRepository
+import javax.inject.Inject
+
+class GetSendNotificationUseCase @Inject constructor(
+    private val alarmRepository: AlarmRepository
+) {
+    suspend operator fun invoke(latitude: Double, longitude: Double): Result<String> {
+        return alarmRepository.getSendNotification(latitude, longitude)
+    }
+} 

--- a/domain/src/main/java/project/graduation/crowd_sourcing/domain/usecase/PostAcceptUseCase.kt
+++ b/domain/src/main/java/project/graduation/crowd_sourcing/domain/usecase/PostAcceptUseCase.kt
@@ -1,0 +1,12 @@
+package project.graduation.crowd_sourcing.domain.usecase
+
+import project.graduation.crowd_sourcing.domain.repository.AlarmRepository
+import javax.inject.Inject
+
+class PostAcceptUseCase @Inject constructor(
+    private val alarmRepository: AlarmRepository
+) {
+    suspend operator fun invoke(workId: Int, memberId: Int): Result<String> {
+        return alarmRepository.postAccept(workId, memberId)
+    }
+} 

--- a/domain/src/main/java/project/graduation/crowd_sourcing/domain/usecase/PostCancelUseCase.kt
+++ b/domain/src/main/java/project/graduation/crowd_sourcing/domain/usecase/PostCancelUseCase.kt
@@ -1,0 +1,12 @@
+package project.graduation.crowd_sourcing.domain.usecase
+
+import project.graduation.crowd_sourcing.domain.repository.AlarmRepository
+import javax.inject.Inject
+
+class PostCancelUseCase @Inject constructor(
+    private val alarmRepository: AlarmRepository
+) {
+    suspend operator fun invoke(workId: Int, memberId: Int): Result<String> {
+        return alarmRepository.postCancel(workId, memberId)
+    }
+} 

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/navigation/Navigation.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/navigation/Navigation.kt
@@ -73,7 +73,7 @@ fun Navigation(
 
 
         composable(route = Screen.BottomScreen.HomeScreen.bRoute) {
-            HomeView()
+            HomeView(navController = navController)
         }
 
         composable(route = Screen.BottomScreen.SearchScreen.bRoute) {

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/navigation/Navigation.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/navigation/Navigation.kt
@@ -103,8 +103,15 @@ fun Navigation(
             RequestCompleteView(navController)
         }
         // 의뢰 수락 화면
-        composable(route = Screen.AcceptRequestScreen.route) {
-            AcceptRequestView(navController = navController)
+        composable(
+            route = Screen.AcceptRequestScreen.routeWithArg,
+            arguments = listOf(navArgument("commissionId") { type = NavType.IntType })
+        ) { backStackEntry ->
+            val commissionId = backStackEntry.arguments?.getInt("commissionId") ?: 0
+            AcceptRequestView(
+                navController = navController,
+                commissionId = commissionId
+            )
         }
 
         // 의뢰 수락 완료 화면

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/navigation/Navigation.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/navigation/Navigation.kt
@@ -38,6 +38,7 @@ import project.graduation.crowd_sourcing.presentation.ui.screen.search.FilterSel
 import project.graduation.crowd_sourcing.presentation.ui.screen.search.SearchResultView
 import project.graduation.crowd_sourcing.presentation.ui.screen.search.SearchView
 import project.graduation.crowd_sourcing.presentation.ui.screen.stats.StatsView
+import project.graduation.crowd_sourcing.presentation.ui.screen.home.component.CurrentRequestsFullView
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -88,6 +89,11 @@ fun Navigation(
         // 검색 결과 화면
         composable(route = Screen.SearchResultScreen.route) {
             SearchResultView(navController = navController)
+        }
+        
+        // 전체 현재 의뢰 화면
+        composable(route = Screen.CurrentRequestsFullScreen.route) {
+            CurrentRequestsFullView(navController = navController)
         }
 
         // 의뢰 탭 최초 화면

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/navigation/Screen.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/navigation/Screen.kt
@@ -55,6 +55,9 @@ sealed class Screen(val title: String, val route: String) {
     // 검색 관련 화면
     data object FilterSelectionScreen: Screen(title = "필터 선택", route = "filter_selection")
     data object SearchResultScreen: Screen(title = "검색 결과", route = "search_result")
+    
+    // 현재 의뢰 관련 화면
+    data object CurrentRequestsFullScreen: Screen(title = "전체 현재 의뢰", route = "current_requests_full")
 
     sealed class BottomScreen(
         val bTitle: String, val bRoute: String, @DrawableRes val icon: Int
@@ -111,6 +114,7 @@ sealed class Screen(val title: String, val route: String) {
                 
                 FilterSelectionScreen.route -> FilterSelectionScreen
                 SearchResultScreen.route -> SearchResultScreen
+                CurrentRequestsFullScreen.route -> CurrentRequestsFullScreen
 
                 BottomScreen.HomeScreen.bRoute -> BottomScreen.HomeScreen
                 BottomScreen.SearchScreen.bRoute -> BottomScreen.SearchScreen

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/navigation/Screen.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/navigation/Screen.kt
@@ -16,7 +16,10 @@ sealed class Screen(val title: String, val route: String) {
     data object RequestCompleteScreen : Screen(title = "의뢰 완료", route = "request_complete")
 
     // 의뢰 수락 관련 화면
-    data object AcceptRequestScreen : Screen(title = "의뢰 수락", route = "accept_request")
+    data object AcceptRequestScreen : Screen(title = "의뢰 수락", route = "accept_request/{commissionId}") {
+        const val routeWithArg = "accept_request/{commissionId}"
+        fun createRoute(commissionId: Int): String = "accept_request/$commissionId"
+    }
     data object AcceptCompleteScreen : Screen(title = "의뢰 수락 완료", route = "acceptComplete/{place}/{title}/{reward}") {
         fun createRoute(place: String, title: String): String =
             "acceptComplete/$place/$title"
@@ -92,7 +95,7 @@ sealed class Screen(val title: String, val route: String) {
                 RequestFormScreen.route -> RequestFormScreen
                 RequestCompleteScreen.route -> RequestCompleteScreen
 
-                AcceptRequestScreen.route -> AcceptRequestScreen
+                AcceptRequestScreen.routeWithArg -> AcceptRequestScreen
                 AcceptCompleteScreen.route -> AcceptCompleteScreen
 
                 WorkListScreen.route -> WorkListScreen

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/HomeView.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/HomeView.kt
@@ -88,7 +88,7 @@ import project.graduation.crowd_sourcing.presentation.ui.theme.CrowdSourcingThem
 @SuppressLint("RememberReturnType")
 @OptIn(ExperimentalPermissionsApi::class, ExperimentalComposeUiApi::class)
 @Composable
-fun HomeView() {
+fun HomeView(navController: androidx.navigation.NavController) {
     val viewModel: HomeViewModel = hiltViewModel()
     val uiState = viewModel.uiState.collectAsState()
     val context = LocalContext.current
@@ -228,7 +228,7 @@ fun HomeView() {
 
                         Spacer(modifier = Modifier.height(dimensionResource(R.dimen.space_medium)))
 
-                        RequestsSection(viewModel = viewModel, state = state)
+                        RequestsSection(viewModel = viewModel, state = state, navController = navController)
 
                         Spacer(modifier = Modifier.height(dimensionResource(R.dimen.space_medium)))
 
@@ -266,7 +266,11 @@ fun HomeView() {
                     MartRequestDialog(
                         mart = state.selectedMart,
                         requests = state.selectedMartRequests,
-                        onDismiss = viewModel::hideMartRequestDialog
+                        onDismiss = viewModel::hideMartRequestDialog,
+                        onRequestClick = { request ->
+                            // 의뢰 클릭 시 AcceptRequestView로 이동
+                            navController.navigate("accept_request")
+                        }
                     )
                 }
             } else {
@@ -281,6 +285,6 @@ fun HomeView() {
 @Composable
 fun HomeViewPreview(){
     CrowdSourcingTheme{
-        HomeView()
+        HomeView(navController = androidx.navigation.compose.rememberNavController())
     }
 }

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/HomeView.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/HomeView.kt
@@ -269,8 +269,7 @@ fun HomeView(navController: androidx.navigation.NavController) {
                         onDismiss = viewModel::hideMartRequestDialog,
                         onRequestClick = { request ->
                             // 의뢰 클릭 시 AcceptRequestView로 이동
-                            // 임시로 고정된 commissionId 사용 (추후 실제 request.id를 commissionId로 변환 필요)
-                            val commissionId = 7 // API 예시에서 사용한 commissionId
+                            val commissionId = 7;
                             navController.navigate(project.graduation.crowd_sourcing.presentation.ui.navigation.Screen.AcceptRequestScreen.createRoute(commissionId))
                         }
                     )

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/HomeView.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/HomeView.kt
@@ -269,7 +269,9 @@ fun HomeView(navController: androidx.navigation.NavController) {
                         onDismiss = viewModel::hideMartRequestDialog,
                         onRequestClick = { request ->
                             // 의뢰 클릭 시 AcceptRequestView로 이동
-                            navController.navigate("accept_request")
+                            // 임시로 고정된 commissionId 사용 (추후 실제 request.id를 commissionId로 변환 필요)
+                            val commissionId = 7 // API 예시에서 사용한 commissionId
+                            navController.navigate(project.graduation.crowd_sourcing.presentation.ui.navigation.Screen.AcceptRequestScreen.createRoute(commissionId))
                         }
                     )
                 }

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/HomeView.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/HomeView.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.navigation.NavController
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberPermissionState
 import com.google.android.gms.common.GoogleApiAvailability
@@ -88,7 +89,7 @@ import project.graduation.crowd_sourcing.presentation.ui.theme.CrowdSourcingThem
 @SuppressLint("RememberReturnType")
 @OptIn(ExperimentalPermissionsApi::class, ExperimentalComposeUiApi::class)
 @Composable
-fun HomeView(navController: androidx.navigation.NavController) {
+fun HomeView(navController: NavController) {
     val viewModel: HomeViewModel = hiltViewModel()
     val uiState = viewModel.uiState.collectAsState()
     val context = LocalContext.current

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/component/CurrentRequestsFullView.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/component/CurrentRequestsFullView.kt
@@ -1,0 +1,101 @@
+package project.graduation.crowd_sourcing.presentation.ui.screen.home.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import project.graduation.crowd_sourcing.presentation.ui.component.list.CommonList
+import project.graduation.crowd_sourcing.presentation.ui.component.list.CommonListItemData
+import project.graduation.crowd_sourcing.presentation.ui.screen.home.HomeUiState
+import project.graduation.crowd_sourcing.presentation.ui.screen.home.HomeViewModel
+
+/**
+ * 전체 현재 의뢰 목록을 보여주는 화면
+ */
+@Composable
+fun CurrentRequestsFullView(
+    navController: NavController,
+    viewModel: HomeViewModel = hiltViewModel()
+) {
+    val uiState = viewModel.uiState.collectAsState()
+    
+    // 현재 의뢰 목록 로드
+    LaunchedEffect(Unit) {
+        viewModel.loadCurrentRequests()
+    }
+    
+    when (val state = uiState.value) {
+        is HomeUiState.Loading -> {
+            // 로딩 중일 때는 간단한 텍스트 표시
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+            ) {
+                Text(text = "로딩 중...")
+            }
+        }
+        is HomeUiState.Error -> {
+            // 에러 상태 표시
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+            ) {
+                Text(
+                    text = "오류가 발생했습니다: ${state.message}",
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+        is HomeUiState.Success -> {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+            ) {
+                if (state.currentRequests.isEmpty()) {
+                    Text(
+                        text = "현재 진행 중인 의뢰가 없습니다.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                } else {
+                    Text(
+                        text = "총 ${state.currentRequests.size}개의 의뢰",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    
+                    Spacer(modifier = Modifier.height(16.dp))
+                    
+                    CommonList(
+                        list = state.currentRequests.map { request ->
+                            CommonListItemData(
+                                mainText = request.title,
+                                subText = request.place,
+                                leftText = "리워드 : ${request.reward}p",
+                                onClick = {
+                                    val commissionId = request.id.toInt()
+                                    navController.navigate(
+                                        project.graduation.crowd_sourcing.presentation.ui.navigation.Screen.AcceptRequestScreen.createRoute(commissionId)
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+        }
+    }
+} 

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/component/MartRequestDialog.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/component/MartRequestDialog.kt
@@ -1,5 +1,6 @@
 package project.graduation.crowd_sourcing.presentation.ui.screen.home.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -24,12 +25,14 @@ import project.graduation.crowd_sourcing.domain.model.entity.martsearch.MartEnti
  * @param mart 선택된 마트 정보
  * @param requests 해당 마트의 의뢰 목록
  * @param onDismiss 다이어로그 닫기 콜백
+ * @param onRequestClick 의뢰 클릭 콜백
  */
 @Composable
 fun MartRequestDialog(
     mart: MartEntity,
     requests: List<Request>,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    onRequestClick: (Request) -> Unit = {}
 ) {
     Dialog(onDismissRequest = onDismiss) {
         Surface(
@@ -126,7 +129,13 @@ fun MartRequestDialog(
                             .heightIn(max = 300.dp)
                     ) {
                         items(requests) { request ->
-                            MartRequestItem(request = request)
+                            MartRequestItem(
+                                request = request,
+                                onClick = { 
+                                    onRequestClick(request)
+                                    onDismiss() // 다이얼로그 닫기
+                                }
+                            )
                             if (requests.indexOf(request) < requests.lastIndex) {
                                 Divider(
                                     modifier = Modifier.padding(vertical = 8.dp),
@@ -168,11 +177,17 @@ fun MartRequestDialog(
  * 마트 의뢰 아이템 컴포넌트
  * 
  * @param request 의뢰 정보
+ * @param onClick 클릭 콜백
  */
 @Composable
-private fun MartRequestItem(request: Request) {
+private fun MartRequestItem(
+    request: Request,
+    onClick: () -> Unit = {}
+) {
     Surface(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
         shape = RoundedCornerShape(8.dp),
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.1f)
     ) {

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/component/RequestSection.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/component/RequestSection.kt
@@ -98,7 +98,9 @@ fun CurrentRequestsList(
                 subText = it.place,
                 leftText = "리워드 : ${it.reward}p",
                 onClick = {
-                    navController?.navigate("accept_request")
+                    // 임시로 고정된 commissionId 사용 (추후 실제 it.id를 commissionId로 변환 필요)
+                    val commissionId = 7 // API 예시에서 사용한 commissionId
+                    navController?.navigate(project.graduation.crowd_sourcing.presentation.ui.navigation.Screen.AcceptRequestScreen.createRoute(commissionId))
                 }
             )
         }
@@ -133,7 +135,9 @@ fun RecommendedRequestsList(
                 subText = it.place,
                 leftText = "리워드 : ${it.reward}p",
                 onClick = {
-                    navController?.navigate("accept_request")
+                    // 임시로 고정된 commissionId 사용 (추후 실제 it.id를 commissionId로 변환 필요)
+                    val commissionId = 7 // API 예시에서 사용한 commissionId
+                    navController?.navigate(project.graduation.crowd_sourcing.presentation.ui.navigation.Screen.AcceptRequestScreen.createRoute(commissionId))
                 }
             )
         }

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/component/RequestSection.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/component/RequestSection.kt
@@ -9,9 +9,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -26,6 +28,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
 import project.graduation.crowd_sourcing.presentation.R
 import project.graduation.crowd_sourcing.presentation.ui.component.list.CommonList
 import project.graduation.crowd_sourcing.presentation.ui.component.list.CommonListItemData
@@ -36,7 +39,7 @@ import project.graduation.crowd_sourcing.presentation.ui.screen.home.HomeViewMod
 fun RequestsSection(
     viewModel: HomeViewModel,
     state: HomeUiState.Success,
-    navController: androidx.navigation.NavController? = null
+    navController: NavController
 ) {
     // 현재 의뢰 목록
     Surface(
@@ -69,7 +72,7 @@ fun RequestsSection(
 fun CurrentRequestsList(
     viewModel: HomeViewModel,
     state: HomeUiState.Success,
-    navController: androidx.navigation.NavController? = null
+    navController: NavController
 ) {
     // 현재 작업중인 의뢰 목록을 로드하는 LaunchedEffect
     LaunchedEffect(Unit) {
@@ -87,30 +90,56 @@ fun CurrentRequestsList(
             text = "현재 의뢰",
             style = MaterialTheme.typography.titleMedium
         )
-//        IconButton(onClick = {}) {
-//            Icon(imageVector = Icons.Default.ArrowForward, contentDescription = null)
-//        }
+        
+        // "+" 버튼 추가
+        IconButton(
+            onClick = {
+                // 전체 현재 의뢰 목록 화면으로 이동
+                navController.navigate(project.graduation.crowd_sourcing.presentation.ui.navigation.Screen.CurrentRequestsFullScreen.route)
+            },
+            modifier = Modifier.size(32.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Add,
+                contentDescription = "전체 현재 의뢰 보기",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
     }
+    
+    // 최근 2개의 현재 의뢰만 표시
+    val recentCurrentRequests = state.currentRequests.take(2)
+    
     CommonList(
-        list = state.currentRequests.map { request ->
+        list = recentCurrentRequests.map { request ->
             CommonListItemData(
                 mainText = request.title,
                 subText = request.place,
                 leftText = "리워드 : ${request.reward}p",
                 onClick = {
                     val commissionId = request.id.toInt()
-                    navController?.navigate(project.graduation.crowd_sourcing.presentation.ui.navigation.Screen.AcceptRequestScreen.createRoute(commissionId))
+                    navController.navigate(project.graduation.crowd_sourcing.presentation.ui.navigation.Screen.AcceptRequestScreen.createRoute(commissionId))
                 }
             )
         }
     )
+    
+    // 더 많은 의뢰가 있다면 표시
+    if (state.currentRequests.size > 2) {
+        Text(
+            text = "외 ${state.currentRequests.size - 2}개의 의뢰가 더 있습니다",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+        )
+    }
 }
 
 @Composable
 fun RecommendedRequestsList(
     viewModel: HomeViewModel,
     state: HomeUiState.Success,
-    navController: androidx.navigation.NavController? = null
+    navController: NavController
 ) {
     Row(
         modifier = Modifier
@@ -134,9 +163,8 @@ fun RecommendedRequestsList(
                 subText = it.place,
                 leftText = "리워드 : ${it.reward}p",
                 onClick = {
-                    // 임시로 고정된 commissionId 사용 (추후 실제 it.id를 commissionId로 변환 필요)
-                    val commissionId = 7 // API 예시에서 사용한 commissionId
-                    navController?.navigate(project.graduation.crowd_sourcing.presentation.ui.navigation.Screen.AcceptRequestScreen.createRoute(commissionId))
+                    val commissionId = it.id.toInt()
+                    navController.navigate(project.graduation.crowd_sourcing.presentation.ui.navigation.Screen.AcceptRequestScreen.createRoute(commissionId))
                 }
             )
         }
@@ -150,6 +178,7 @@ fun RequestsSectionPrev() {
     val viewModel: HomeViewModel = viewModel()
     RequestsSection(
         viewModel = viewModel,
-        state = (viewModel.uiState.value as HomeUiState.Success)
+        state = (viewModel.uiState.value as HomeUiState.Success),
+        navController = androidx.navigation.compose.rememberNavController()
     )
 }

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/component/RequestSection.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/component/RequestSection.kt
@@ -35,7 +35,8 @@ import project.graduation.crowd_sourcing.presentation.ui.screen.home.HomeViewMod
 @Composable
 fun RequestsSection(
     viewModel: HomeViewModel,
-    state: HomeUiState.Success
+    state: HomeUiState.Success,
+    navController: androidx.navigation.NavController? = null
 ) {
     // 현재 의뢰 목록
     Surface(
@@ -45,7 +46,7 @@ fun RequestsSection(
         shape = RoundedCornerShape(8.dp)
     ) {
         Column(modifier = Modifier.wrapContentSize()) {
-            CurrentRequestsList(viewModel = viewModel, state = state)
+            CurrentRequestsList(viewModel = viewModel, state = state, navController = navController)
         }
     }
 
@@ -59,7 +60,7 @@ fun RequestsSection(
         shape = RoundedCornerShape(8.dp)
     ) {
         Column(modifier = Modifier.wrapContentSize()) {
-            RecommendedRequestsList(viewModel = viewModel, state = state)
+            RecommendedRequestsList(viewModel = viewModel, state = state, navController = navController)
         }
     }
 }
@@ -67,7 +68,8 @@ fun RequestsSection(
 @Composable
 fun CurrentRequestsList(
     viewModel: HomeViewModel,
-    state: HomeUiState.Success
+    state: HomeUiState.Success,
+    navController: androidx.navigation.NavController? = null
 ) {
     // 현재 작업중인 의뢰 목록을 로드하는 LaunchedEffect
     LaunchedEffect(Unit) {
@@ -95,7 +97,9 @@ fun CurrentRequestsList(
                 mainText = it.title,
                 subText = it.place,
                 leftText = "리워드 : ${it.reward}p",
-                onClick = {}
+                onClick = {
+                    navController?.navigate("accept_request")
+                }
             )
         }
     )
@@ -104,7 +108,8 @@ fun CurrentRequestsList(
 @Composable
 fun RecommendedRequestsList(
     viewModel: HomeViewModel,
-    state: HomeUiState.Success
+    state: HomeUiState.Success,
+    navController: androidx.navigation.NavController? = null
 ) {
     Row(
         modifier = Modifier
@@ -127,7 +132,9 @@ fun RecommendedRequestsList(
                 mainText = it.title,
                 subText = it.place,
                 leftText = "리워드 : ${it.reward}p",
-                onClick = {}
+                onClick = {
+                    navController?.navigate("accept_request")
+                }
             )
         }
     )

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/component/RequestSection.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/home/component/RequestSection.kt
@@ -92,14 +92,13 @@ fun CurrentRequestsList(
 //        }
     }
     CommonList(
-        list = state.currentRequests.map {
+        list = state.currentRequests.map { request ->
             CommonListItemData(
-                mainText = it.title,
-                subText = it.place,
-                leftText = "리워드 : ${it.reward}p",
+                mainText = request.title,
+                subText = request.place,
+                leftText = "리워드 : ${request.reward}p",
                 onClick = {
-                    // 임시로 고정된 commissionId 사용 (추후 실제 it.id를 commissionId로 변환 필요)
-                    val commissionId = 7 // API 예시에서 사용한 commissionId
+                    val commissionId = request.id.toInt()
                     navController?.navigate(project.graduation.crowd_sourcing.presentation.ui.navigation.Screen.AcceptRequestScreen.createRoute(commissionId))
                 }
             )

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestUiState.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestUiState.kt
@@ -7,5 +7,7 @@ data class AcceptRequestUiState(
     val title: String = "",
     val reward: Int = 0,
     val participant: String = "",
-    val deadline: String = ""
+    val deadline: String = "",
+    val latitude: Double = 37.5818, // 청량리 롯데마트 위도 (기본값)
+    val longitude: Double = 127.0368 // 청량리 롯데마트 경도 (기본값)
 )

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestUiState.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestUiState.kt
@@ -2,12 +2,18 @@ package project.graduation.crowd_sourcing.presentation.ui.screen.request.accept
 
 // 의뢰 수락 UiState
 data class AcceptRequestUiState(
-    val id: String = "",
-    val place: String = "",
-    val title: String = "",
-    val reward: Int = 0,
-    val participant: String = "",
-    val deadline: String = "",
+    val commissionId: Int = 0,
+    val commission: String = "",
+    val region: String = "",
+    val martName: String = "",
+    val category: String = "",
+    val item: String = "",
+    val commissionPoint: Int = 0,
+    val commissionCount: Int = 0,
+    val createdAt: String = "",
+    val expirationDate: String = "",
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
     val latitude: Double = 37.5818, // 청량리 롯데마트 위도 (기본값)
     val longitude: Double = 127.0368 // 청량리 롯데마트 경도 (기본값)
 )

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestUiState.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestUiState.kt
@@ -15,5 +15,8 @@ data class AcceptRequestUiState(
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
     val latitude: Double = 37.5818, // 청량리 롯데마트 위도 (기본값)
-    val longitude: Double = 127.0368 // 청량리 롯데마트 경도 (기본값)
+    val longitude: Double = 127.0368, // 청량리 롯데마트 경도 (기본값)
+    val isAcceptLoading: Boolean = false,
+    val isAcceptSuccess: Boolean = false,
+    val acceptErrorMessage: String? = null
 )

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestView.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestView.kt
@@ -2,15 +2,22 @@ package project.graduation.crowd_sourcing.presentation.ui.screen.request.accept
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import project.graduation.crowd_sourcing.presentation.ui.component.ConfirmButton
@@ -18,45 +25,64 @@ import project.graduation.crowd_sourcing.presentation.ui.screen.request.componen
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.rememberNavController
 import project.graduation.crowd_sourcing.presentation.ui.component.GrayDivider
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.map.CameraPosition
+import com.naver.maps.map.compose.*
 
 // 의뢰 수락 페이지
 @Composable
 fun AcceptRequestView(
     navController: NavController,
+    requestId: String? = null, // 의뢰 ID 파라미터 추가
     viewModel: AcceptRequestViewModel = viewModel()
 ) {
     val uiState = viewModel.uiState
 
-    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-        // 지도 (대체 이미지 or 네이버 지도)
-        Box(
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(20.dp) // 전체 패딩 증가
+    ) {
+        // 네이버 지도 (청량리 롯데마트 위치) - 지도 경계와 그림자 추가
+        Surface(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(180.dp)
-                .background(Color.LightGray),
-            contentAlignment = Alignment.Center
+                .height(320.dp) // 지도 높이 증가
+                .padding(bottom = 24.dp), // 간격 증가
+            shape = RoundedCornerShape(12.dp), // 모서리 둥글게
+            shadowElevation = 4.dp, // 그림자 추가
+            color = MaterialTheme.colorScheme.surface
         ) {
-            Text("${uiState.place}", style = MaterialTheme.typography.bodyLarge)
+            AcceptRequestMapView(
+                latitude = uiState.latitude,
+                longitude = uiState.longitude,
+                title = uiState.place
+            )
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        // 의뢰 정보 제목 - 글자 크기와 굵기 증가
+        Text(
+            text = "의뢰 정보",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            fontSize = 20.sp,
+            modifier = Modifier.padding(bottom = 16.dp) // 간격 증가
+        )
 
-        Text("의뢰 정보", style = MaterialTheme.typography.titleMedium)
-        Spacer(modifier = Modifier.height(8.dp))
-
+        // 의뢰 정보 목록
         Column {
-            WorkInfo(Icons.Default.Place, "위치", uiState.place)
+            AcceptRequestWorkInfo(Icons.Default.Place, "위치", uiState.place)
             GrayDivider()
-            WorkInfo(Icons.Default.Groups, "참여인원", uiState.participant)
+            AcceptRequestWorkInfo(Icons.Default.Groups, "참여인원", uiState.participant)
             GrayDivider()
-            WorkInfo(Icons.Default.Diamond, "리워드", "${uiState.reward}")
+            AcceptRequestWorkInfo(Icons.Default.Diamond, "리워드", "${uiState.reward}")
             GrayDivider()
-            WorkInfo(Icons.Default.Edit, "의뢰 내역", uiState.title)
+            AcceptRequestWorkInfo(Icons.Default.Edit, "의뢰 내역", uiState.title)
             GrayDivider()
-            WorkInfo(Icons.Default.AccessTime, "의뢰 마감", uiState.deadline)
+            AcceptRequestWorkInfo(Icons.Default.AccessTime, "의뢰 마감", uiState.deadline)
         }
 
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(8.dp)) // 간격 증가
 
         ConfirmButton(
             text = "수락",
@@ -70,6 +96,86 @@ fun AcceptRequestView(
     }
 }
 
+// AcceptRequestView 전용 WorkInfo 컴포넌트 (SpaceBetween 레이아웃 적용)
+@Composable
+private fun AcceptRequestWorkInfo(
+    icon: ImageVector,
+    label: String,
+    value: String
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 18.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(24.dp)
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        
+        // label과 value를 SpaceBetween으로 배치
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                fontSize = 16.sp
+            )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Normal,
+                fontSize = 16.sp
+            )
+        }
+    }
+}
+
+// 의뢰 수락 페이지용 네이버 맵 컴포넌트
+@OptIn(ExperimentalNaverMapApi::class)
+@Composable
+fun AcceptRequestMapView(
+    latitude: Double,
+    longitude: Double,
+    title: String
+) {
+    val martLatLng = LatLng(latitude, longitude)
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition(martLatLng, 16.0) // 줌 레벨 16
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+    ) {
+        NaverMap(
+            modifier = Modifier
+                .fillMaxSize(),
+            cameraPositionState = cameraPositionState,
+            properties = MapProperties(isBuildingLayerGroupEnabled = true),
+            uiSettings = MapUiSettings(
+                isZoomControlEnabled = false,
+                isLocationButtonEnabled = false,
+                isCompassEnabled = false,
+                isScaleBarEnabled = false
+            )
+        ) {
+            Marker(
+                state = MarkerState(position = martLatLng),
+                captionText = title
+            )
+        }
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 fun AcceptRequestViewPreview() {
@@ -77,17 +183,19 @@ fun AcceptRequestViewPreview() {
         init {
             uiState = AcceptRequestUiState(
                 id = "1",
-                place = "상암 홈플러스",
+                place = "청량리 롯데마트",
                 title = "딸기 한 박스",
                 reward = 100,
                 participant = "2/5",
-                deadline = "2025/04/18 (금) 00:00"
+                deadline = "2025/04/18 (금) 00:00",
+                latitude = 37.5818, // 청량리 롯데마트 위도
+                longitude = 127.0368 // 청량리 롯데마트 경도
             )
         }
     }
 
     AcceptRequestView(
-        navController = rememberNavController(), // 더미 네비게이터
+        navController = rememberNavController(),
         viewModel = acceptViewModel
     )
 }

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestView.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestView.kt
@@ -2,7 +2,9 @@ package project.graduation.crowd_sourcing.presentation.ui.screen.request.accept
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.Icon
@@ -15,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -37,17 +40,24 @@ fun AcceptRequestView(
     viewModel: AcceptRequestViewModel = viewModel()
 ) {
     val uiState = viewModel.uiState
+    val configuration = LocalConfiguration.current
+    val screenHeight = configuration.screenHeightDp.dp
+    val scrollState = rememberScrollState()
+    
+    // 화면 높이에 따라 지도 높이를 동적으로 조절 (화면의 35~40% 정도)
+    val mapHeight = (screenHeight * 0.38f).coerceAtMost(320.dp).coerceAtLeast(200.dp)
 
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .verticalScroll(scrollState) // 스크롤 가능하게 설정
             .padding(20.dp) // 전체 패딩 증가
     ) {
         // 네이버 지도 (청량리 롯데마트 위치) - 지도 경계와 그림자 추가
         Surface(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(320.dp) // 지도 높이 증가
+                .height(mapHeight) // 동적 높이 적용
                 .padding(bottom = 24.dp), // 간격 증가
             shape = RoundedCornerShape(12.dp), // 모서리 둥글게
             shadowElevation = 4.dp, // 그림자 추가
@@ -82,7 +92,7 @@ fun AcceptRequestView(
             AcceptRequestWorkInfo(Icons.Default.AccessTime, "의뢰 마감", uiState.deadline)
         }
 
-        Spacer(modifier = Modifier.height(8.dp)) // 간격 증가
+        Spacer(modifier = Modifier.height(24.dp)) // 간격 증가
 
         ConfirmButton(
             text = "수락",
@@ -93,6 +103,9 @@ fun AcceptRequestView(
             },
             modifier = Modifier.fillMaxWidth()
         )
+        
+        // 하단 여백 추가하여 버튼이 화면 끝에 붙지 않도록 함
+//        Spacer(modifier = Modifier.height(8.dp))
     }
 }
 

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestView.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestView.kt
@@ -1,5 +1,7 @@
 package project.graduation.crowd_sourcing.presentation.ui.screen.request.accept
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -7,11 +9,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
@@ -21,91 +25,129 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import project.graduation.crowd_sourcing.presentation.ui.component.ConfirmButton
-import project.graduation.crowd_sourcing.presentation.ui.screen.request.component.WorkInfo
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation.compose.rememberNavController
 import project.graduation.crowd_sourcing.presentation.ui.component.GrayDivider
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraPosition
 import com.naver.maps.map.compose.*
 
 // 의뢰 수락 페이지
+@OptIn(ExperimentalNaverMapApi::class)
+@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun AcceptRequestView(
     navController: NavController,
-    requestId: String? = null, // 의뢰 ID 파라미터 추가
-    viewModel: AcceptRequestViewModel = viewModel()
+    commissionId: Int,
+    viewModel: AcceptRequestViewModel = hiltViewModel()
 ) {
     val uiState = viewModel.uiState
     val configuration = LocalConfiguration.current
     val screenHeight = configuration.screenHeightDp.dp
-    val scrollState = rememberScrollState()
-    
-    // 화면 높이에 따라 지도 높이를 동적으로 조절 (화면의 35~40% 정도)
-    val mapHeight = (screenHeight * 0.38f).coerceAtMost(320.dp).coerceAtLeast(200.dp)
+
+    // commissionId가 변경될 때마다 데이터를 로드
+    LaunchedEffect(commissionId) {
+        viewModel.loadCommissionDetail(commissionId)
+    }
+
+    // 로딩 상태 처리
+    if (uiState.isLoading) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
+        return
+    }
+
+    // 에러 상태 처리
+    uiState.errorMessage?.let { errorMessage ->
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = errorMessage,
+                color = Color.Red,
+                modifier = Modifier.padding(24.dp)
+            )
+        }
+        return
+    }
 
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .verticalScroll(scrollState) // 스크롤 가능하게 설정
-            .padding(20.dp) // 전체 패딩 증가
+            .padding(horizontal = 24.dp)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        // 네이버 지도 (청량리 롯데마트 위치) - 지도 경계와 그림자 추가
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // 카카오맵을 사용한 지도 섹션
         Surface(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(mapHeight) // 동적 높이 적용
-                .padding(bottom = 24.dp), // 간격 증가
-            shape = RoundedCornerShape(12.dp), // 모서리 둥글게
-            shadowElevation = 4.dp, // 그림자 추가
+                .height(screenHeight * 0.25f)
+                .shadow(2.dp, RoundedCornerShape(8.dp)),
+            shape = RoundedCornerShape(8.dp),
             color = MaterialTheme.colorScheme.surface
         ) {
-            AcceptRequestMapView(
-                latitude = uiState.latitude,
-                longitude = uiState.longitude,
-                title = uiState.place
-            )
+            val position = LatLng(uiState.latitude, uiState.longitude)
+            val cameraPositionState = rememberCameraPositionState {
+                this.position = CameraPosition(position, 15.0)
+            }
+
+            NaverMap(
+                modifier = Modifier.fillMaxSize(),
+                cameraPositionState = cameraPositionState
+            ) {
+                Marker(
+                    state = MarkerState(position = position),
+                    captionText = uiState.martName
+                )
+            }
         }
 
-        // 의뢰 정보 제목 - 글자 크기와 굵기 증가
+        // 의뢰 정보 제목
         Text(
             text = "의뢰 정보",
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
             fontSize = 20.sp,
-            modifier = Modifier.padding(bottom = 16.dp) // 간격 증가
+            modifier = Modifier.padding(bottom = 8.dp)
         )
 
         // 의뢰 정보 목록
         Column {
-            AcceptRequestWorkInfo(Icons.Default.Place, "위치", uiState.place)
+            AcceptRequestWorkInfo(Icons.Default.Place, "위치", "${uiState.region} ${uiState.martName}")
             GrayDivider()
-            AcceptRequestWorkInfo(Icons.Default.Groups, "참여인원", uiState.participant)
+            AcceptRequestWorkInfo(Icons.Default.Category, "카테고리", uiState.category)
             GrayDivider()
-            AcceptRequestWorkInfo(Icons.Default.Diamond, "리워드", "${uiState.reward}")
+            AcceptRequestWorkInfo(Icons.Default.ShoppingCart, "상품", uiState.item)
             GrayDivider()
-            AcceptRequestWorkInfo(Icons.Default.Edit, "의뢰 내역", uiState.title)
+            AcceptRequestWorkInfo(Icons.Default.Groups, "참여인원", "${uiState.commissionCount}명")
             GrayDivider()
-            AcceptRequestWorkInfo(Icons.Default.AccessTime, "의뢰 마감", uiState.deadline)
+            AcceptRequestWorkInfo(Icons.Default.Diamond, "리워드", "${uiState.commissionPoint}P")
+            GrayDivider()
+            AcceptRequestWorkInfo(Icons.Default.Edit, "의뢰 내역", uiState.commission)
+            GrayDivider()
+            AcceptRequestWorkInfo(Icons.Default.AccessTime, "의뢰 마감", uiState.expirationDate)
         }
 
-        Spacer(modifier = Modifier.height(24.dp)) // 간격 증가
+        Spacer(modifier = Modifier.height(24.dp))
 
         ConfirmButton(
             text = "수락",
             onConfirm = {
                 navController.navigate(
-                    "acceptComplete/${uiState.place}/${uiState.title}/${uiState.reward}"
+                    "acceptComplete/${uiState.martName}/${uiState.commission}/${uiState.commissionPoint}"
                 )
             },
             modifier = Modifier.fillMaxWidth()
         )
-        
-        // 하단 여백 추가하여 버튼이 화면 끝에 붙지 않도록 함
-//        Spacer(modifier = Modifier.height(8.dp))
     }
 }
 
@@ -150,65 +192,4 @@ private fun AcceptRequestWorkInfo(
             )
         }
     }
-}
-
-// 의뢰 수락 페이지용 네이버 맵 컴포넌트
-@OptIn(ExperimentalNaverMapApi::class)
-@Composable
-fun AcceptRequestMapView(
-    latitude: Double,
-    longitude: Double,
-    title: String
-) {
-    val martLatLng = LatLng(latitude, longitude)
-    val cameraPositionState = rememberCameraPositionState {
-        position = CameraPosition(martLatLng, 16.0) // 줌 레벨 16
-    }
-
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-    ) {
-        NaverMap(
-            modifier = Modifier
-                .fillMaxSize(),
-            cameraPositionState = cameraPositionState,
-            properties = MapProperties(isBuildingLayerGroupEnabled = true),
-            uiSettings = MapUiSettings(
-                isZoomControlEnabled = false,
-                isLocationButtonEnabled = false,
-                isCompassEnabled = false,
-                isScaleBarEnabled = false
-            )
-        ) {
-            Marker(
-                state = MarkerState(position = martLatLng),
-                captionText = title
-            )
-        }
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun AcceptRequestViewPreview() {
-    val acceptViewModel = object : AcceptRequestViewModel() {
-        init {
-            uiState = AcceptRequestUiState(
-                id = "1",
-                place = "청량리 롯데마트",
-                title = "딸기 한 박스",
-                reward = 100,
-                participant = "2/5",
-                deadline = "2025/04/18 (금) 00:00",
-                latitude = 37.5818, // 청량리 롯데마트 위도
-                longitude = 127.0368 // 청량리 롯데마트 경도
-            )
-        }
-    }
-
-    AcceptRequestView(
-        navController = rememberNavController(),
-        viewModel = acceptViewModel
-    )
 }

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestView.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestView.kt
@@ -9,11 +9,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
@@ -75,6 +77,31 @@ fun AcceptRequestView(
             )
         }
         return
+    }
+
+    // 수락 성공 시 자동으로 완료 페이지로 이동
+    LaunchedEffect(uiState.isAcceptSuccess) {
+        if (uiState.isAcceptSuccess) {
+            navController.navigate(
+                "acceptComplete/${uiState.martName}/${uiState.commission}/${uiState.commissionPoint}"
+            )
+        }
+    }
+
+    // 수락 실패 다이얼로그
+    uiState.acceptErrorMessage?.let { errorMessage ->
+        AlertDialog(
+            onDismissRequest = { viewModel.clearAcceptError() },
+            title = { Text("수락 실패") },
+            text = { Text(errorMessage) },
+            confirmButton = {
+                TextButton(
+                    onClick = { viewModel.clearAcceptError() }
+                ) {
+                    Text("확인")
+                }
+            }
+        )
     }
 
     Column(
@@ -140,11 +167,11 @@ fun AcceptRequestView(
         Spacer(modifier = Modifier.height(24.dp))
 
         ConfirmButton(
-            text = "수락",
+            text = if (uiState.isAcceptLoading) "처리 중..." else "수락",
             onConfirm = {
-                navController.navigate(
-                    "acceptComplete/${uiState.martName}/${uiState.commission}/${uiState.commissionPoint}"
-                )
+                if (!uiState.isAcceptLoading) {
+                    viewModel.acceptRequest()
+                }
             },
             modifier = Modifier.fillMaxWidth()
         )

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestViewModel.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestViewModel.kt
@@ -10,11 +10,36 @@ open class AcceptRequestViewModel : ViewModel() {
     var uiState by mutableStateOf(
         AcceptRequestUiState(
             id = "1",
-            place = "상암 홈플러스",
+            place = "청량리 롯데마트",
             title = "딸기 한 박스",
             reward = 100,
             participant = "2/5",
-            deadline = "2025/04/18 (금) 00:00"
+            deadline = "2025/04/18 (금) 00:00",
+            latitude = 37.5818, // 청량리 롯데마트 위도
+            longitude = 127.0368 // 청량리 롯데마트 경도
         )
     )
+
+    // 의뢰 정보를 외부에서 설정할 수 있는 함수 (추후 백엔드 연동용)
+    fun setRequestInfo(
+        id: String,
+        place: String,
+        title: String,
+        reward: Int,
+        participant: String,
+        deadline: String,
+        latitude: Double,
+        longitude: Double
+    ) {
+        uiState = AcceptRequestUiState(
+            id = id,
+            place = place,
+            title = title,
+            reward = reward,
+            participant = participant,
+            deadline = deadline,
+            latitude = latitude,
+            longitude = longitude
+        )
+    }
 }

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestViewModel.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestViewModel.kt
@@ -9,14 +9,18 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import project.graduation.crowd_sourcing.domain.local.TokenManager
 import project.graduation.crowd_sourcing.domain.usecase.GetCommissionDetailUseCase
+import project.graduation.crowd_sourcing.domain.usecase.PostAcceptUseCase
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 @HiltViewModel
 class AcceptRequestViewModel @Inject constructor(
-    private val getCommissionDetailUseCase: GetCommissionDetailUseCase
+    private val getCommissionDetailUseCase: GetCommissionDetailUseCase,
+    private val postAcceptUseCase: PostAcceptUseCase,
+    private val tokenManager: TokenManager
 ) : ViewModel() {
     
     var uiState by mutableStateOf(AcceptRequestUiState())
@@ -56,5 +60,45 @@ class AcceptRequestViewModel @Inject constructor(
     private fun formatDateTime(dateTime: LocalDateTime): String {
         val formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd (E) HH:mm")
         return dateTime.format(formatter)
+    }
+
+    fun acceptRequest() {
+        val memberId = tokenManager.getUserId()
+        if (memberId == -1) {
+            uiState = uiState.copy(acceptErrorMessage = "사용자 정보를 찾을 수 없습니다.")
+            return
+        }
+
+        uiState = uiState.copy(
+            isAcceptLoading = true,
+            isAcceptSuccess = false,
+            acceptErrorMessage = null
+        )
+
+        viewModelScope.launch {
+            postAcceptUseCase(
+                workId = uiState.commissionId,
+                memberId = memberId
+            ).fold(
+                onSuccess = { message ->
+                    uiState = uiState.copy(
+                        isAcceptLoading = false,
+                        isAcceptSuccess = true
+                    )
+                },
+                onFailure = { throwable ->
+                    uiState = uiState.copy(
+                        isAcceptLoading = false,
+                        acceptErrorMessage = throwable.message ?: "작업 수락에 실패했습니다."
+                    )
+                }
+            )
+        }
+    }
+
+    fun clearAcceptError() {
+        uiState = uiState.copy(
+            acceptErrorMessage = null
+        )
     }
 }

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestViewModel.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/accept/AcceptRequestViewModel.kt
@@ -1,45 +1,60 @@
 package project.graduation.crowd_sourcing.presentation.ui.screen.request.accept
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import project.graduation.crowd_sourcing.domain.usecase.GetCommissionDetailUseCase
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
 
-// 더미 데이터
-open class AcceptRequestViewModel : ViewModel() {
-    var uiState by mutableStateOf(
-        AcceptRequestUiState(
-            id = "1",
-            place = "청량리 롯데마트",
-            title = "딸기 한 박스",
-            reward = 100,
-            participant = "2/5",
-            deadline = "2025/04/18 (금) 00:00",
-            latitude = 37.5818, // 청량리 롯데마트 위도
-            longitude = 127.0368 // 청량리 롯데마트 경도
-        )
-    )
+@HiltViewModel
+class AcceptRequestViewModel @Inject constructor(
+    private val getCommissionDetailUseCase: GetCommissionDetailUseCase
+) : ViewModel() {
+    
+    var uiState by mutableStateOf(AcceptRequestUiState())
+        private set
 
-    // 의뢰 정보를 외부에서 설정할 수 있는 함수 (추후 백엔드 연동용)
-    fun setRequestInfo(
-        id: String,
-        place: String,
-        title: String,
-        reward: Int,
-        participant: String,
-        deadline: String,
-        latitude: Double,
-        longitude: Double
-    ) {
-        uiState = AcceptRequestUiState(
-            id = id,
-            place = place,
-            title = title,
-            reward = reward,
-            participant = participant,
-            deadline = deadline,
-            latitude = latitude,
-            longitude = longitude
-        )
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun loadCommissionDetail(commissionId: Int) {
+        uiState = uiState.copy(isLoading = true, errorMessage = null)
+        
+        viewModelScope.launch {
+            try {
+                val commissionDetail = getCommissionDetailUseCase(commissionId)
+                
+                uiState = uiState.copy(
+                    isLoading = false,
+                    commissionId = commissionDetail.commissionId,
+                    commission = commissionDetail.commission,
+                    region = commissionDetail.region,
+                    martName = commissionDetail.martName,
+                    category = commissionDetail.category,
+                    item = commissionDetail.item,
+                    commissionPoint = commissionDetail.commissionPoint,
+                    commissionCount = commissionDetail.commissionCount,
+                    createdAt = formatDateTime(commissionDetail.createdAt),
+                    expirationDate = formatDateTime(commissionDetail.expirationDate)
+                )
+            } catch (e: Exception) {
+                uiState = uiState.copy(
+                    isLoading = false,
+                    errorMessage = "의뢰 정보를 불러오는데 실패했습니다: ${e.message}"
+                )
+            }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun formatDateTime(dateTime: LocalDateTime): String {
+        val formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd (E) HH:mm")
+        return dateTime.format(formatter)
     }
 }

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/component/WorkInfo.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/request/component/WorkInfo.kt
@@ -10,38 +10,47 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 // 작업 제출 페이지 - 작업 내용 컴포넌트
 @Composable
 fun WorkInfo(
     icon: ImageVector,
     label: String,
-    value: String
+    value: String,
+    verticalPadding: Dp = 8.dp, // 세로 패딩 커스터마이징 가능
+    iconSize: Dp = 20.dp, // 아이콘 크기 커스터마이징 가능
+    spacerWidth: Dp = 12.dp, // 간격 커스터마이징 가능
+    labelWidth: Dp = 80.dp, // 라벨 너비 커스터마이징 가능
+    labelStyle: TextStyle = MaterialTheme.typography.bodyMedium, // 라벨 스타일 커스터마이징 가능
+    valueStyle: TextStyle = MaterialTheme.typography.bodyMedium // 값 스타일 커스터마이징 가능
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 8.dp),
+            .padding(vertical = verticalPadding),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
             imageVector = icon,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.size(20.dp)
+            modifier = Modifier.size(iconSize)
         )
-        Spacer(modifier = Modifier.width(12.dp))
+        Spacer(modifier = Modifier.width(spacerWidth))
         Text(
             text = label,
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.width(80.dp)
+            style = labelStyle,
+            modifier = Modifier.width(labelWidth)
         )
         Text(
             text = value,
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier
-                .weight(1f)
+            style = valueStyle,
+            modifier = Modifier.weight(1f)
         )
     }
 }

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/search/SearchResultView.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/search/SearchResultView.kt
@@ -155,9 +155,14 @@ fun SearchResultView(
                     SearchResultItem(
                         result = result,
                         onItemClick = {
-                            // 임시로 고정된 commissionId 사용 (추후 실제 result.id를 commissionId로 변환 필요)
-                            val commissionId = 7 // API 예시에서 사용한 commissionId
-                            navController.navigate(project.graduation.crowd_sourcing.presentation.ui.navigation.Screen.AcceptRequestScreen.createRoute(commissionId))
+                            try {
+                                val commissionId = result.id.toInt()
+                                navController.navigate(project.graduation.crowd_sourcing.presentation.ui.navigation.Screen.AcceptRequestScreen.createRoute(commissionId))
+                            } catch (e: NumberFormatException) {
+                                // 임시로 고정된 commissionId 사용 (result.id가 숫자가 아닌 경우)
+                                val commissionId = 7 
+                                navController.navigate(project.graduation.crowd_sourcing.presentation.ui.navigation.Screen.AcceptRequestScreen.createRoute(commissionId))
+                            }
                         }
                     )
                     Divider()

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/search/SearchResultView.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/search/SearchResultView.kt
@@ -152,7 +152,12 @@ fun SearchResultView(
                 modifier = Modifier.fillMaxSize()
             ) {
                 items(sortedResults) { result ->
-                    SearchResultItem(result = result)
+                    SearchResultItem(
+                        result = result,
+                        onItemClick = {
+                            navController.navigate("accept_request")
+                        }
+                    )
                     Divider()
                 }
             }
@@ -300,12 +305,13 @@ fun SearchResultFilterBar(
  */
 @Composable
 fun SearchResultItem(
-    result: SearchResult
+    result: SearchResult,
+    onItemClick: () -> Unit = {}
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { /* 아이템 클릭 처리 */ }
+            .clickable { onItemClick() }
             .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/search/SearchResultView.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/search/SearchResultView.kt
@@ -155,7 +155,9 @@ fun SearchResultView(
                     SearchResultItem(
                         result = result,
                         onItemClick = {
-                            navController.navigate("accept_request")
+                            // 임시로 고정된 commissionId 사용 (추후 실제 result.id를 commissionId로 변환 필요)
+                            val commissionId = 7 // API 예시에서 사용한 commissionId
+                            navController.navigate(project.graduation.crowd_sourcing.presentation.ui.navigation.Screen.AcceptRequestScreen.createRoute(commissionId))
                         }
                     )
                     Divider()

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/search/SearchResultView.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/search/SearchResultView.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -50,12 +51,15 @@ import androidx.navigation.NavController
 import project.graduation.crowd_sourcing.presentation.ui.screen.search.component.FilterChip
 import androidx.lifecycle.SavedStateHandle
 import androidx.compose.runtime.LaunchedEffect
+import android.os.Build
+import androidx.annotation.RequiresApi
 
 /**
  * 검색 결과 화면
  * 
  * @param navController 네비게이션 컨트롤러
  */
+@RequiresApi(Build.VERSION_CODES.O)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SearchResultView(
@@ -63,9 +67,6 @@ fun SearchResultView(
 ) {
     val viewModel: SearchViewModel = hiltViewModel()
     val uiState = viewModel.uiState.collectAsState()
-    
-    // 검색 결과를 저장할 상태
-    var searchResults by remember { mutableStateOf<List<SearchResult>>(emptyList()) }
     
     // 화면이 표시될 때 savedStateHandle에서 검색 결과 및 필터 정보 가져오기
     LaunchedEffect(Unit) {
@@ -78,15 +79,16 @@ fun SearchResultView(
             val resultsArray = handle.get<Array<SearchResult>>("searchResults")
             println("DEBUG_RESULT: savedStateHandle에서 searchResults 배열 확인 - ${if (resultsArray != null) "존재 (${resultsArray.size}개)" else "없음"}")
             
-            resultsArray?.let {
-                searchResults = it.toList()
+            val searchResults = resultsArray?.toList() ?: emptyList()
+            
+            if (searchResults.isNotEmpty()) {
                 println("DEBUG_RESULT: 검색 결과를 리스트로 변환 완료 - 크기: ${searchResults.size}")
                 // 디버그를 위해 첫 번째 아이템 출력
-                if (searchResults.isNotEmpty()) {
-                    val first = searchResults.first()
-                    println("DEBUG_RESULT: 첫 번째 결과 - id: ${first.id}, title: ${first.title}, place: '${first.place}', reward: ${first.reward}, remainingDays: ${first.remainingDays}")
-                }
-            } ?: println("DEBUG_RESULT: searchResults 배열이 null")
+                val first = searchResults.first()
+                println("DEBUG_RESULT: 첫 번째 결과 - id: ${first.id}, title: ${first.title}, place: '${first.place}', reward: ${first.reward}, remainingDays: ${first.remainingDays}")
+            } else {
+                println("DEBUG_RESULT: searchResults 배열이 null 또는 비어있음")
+            }
             
             // 검색어, 카테고리, 지역 정보 가져오기
             val searchQuery = handle.get<String>("searchQuery") ?: ""
@@ -95,20 +97,19 @@ fun SearchResultView(
             
             println("DEBUG_RESULT: 필터 정보 확인 - 검색어: '$searchQuery', 카테고리: ${selectedCategory ?: "전체"}, 지역: ${selectedRegion ?: "전체"}")
             
-            // ViewModel 상태 전체 업데이트
-            println("DEBUG_RESULT: viewModel.updateStateWithFilterInfo 호출 전")
-            viewModel.updateStateWithFilterInfo(
-                searchResults = searchResults,
-                searchQuery = searchQuery,
-                selectedCategory = selectedCategory,
-                selectedRegion = selectedRegion
-            )
-            println("DEBUG_RESULT: viewModel.updateStateWithFilterInfo 호출 완료")
-            
-            // 서버에서 데이터를 다시 로드하지 않음 (이미 검색 화면에서 로드했음)
-            // 주석 처리: 디버깅을 위해 나중에 필요할 경우 주석 해제할 수 있음
-            // println("DEBUG_RESULT: 설정된 필터로 새로운 검색 실행")
-            // viewModel.refreshSearch()
+            // ViewModel 상태 전체 업데이트 (검색 결과가 있을 때만)
+            if (searchResults.isNotEmpty()) {
+                println("DEBUG_RESULT: viewModel.updateStateWithFilterInfo 호출 전")
+                viewModel.updateStateWithFilterInfo(
+                    searchResults = searchResults,
+                    searchQuery = searchQuery,
+                    selectedCategory = selectedCategory,
+                    selectedRegion = selectedRegion
+                )
+                println("DEBUG_RESULT: viewModel.updateStateWithFilterInfo 호출 완료")
+            } else {
+                println("DEBUG_RESULT: 검색 결과가 없으므로 상태 업데이트 건너뜀")
+            }
         } ?: println("DEBUG_RESULT: previousBackStackEntry 또는 savedStateHandle이 null")
     }
     
@@ -119,14 +120,26 @@ fun SearchResultView(
     // 현재 선택된 정렬 방식
     var sortType by remember { mutableStateOf(SortType.LATEST) }
     
+    // ViewModel에서 현재 검색 결과 가져오기
+    val currentSearchResults = when (val state = uiState.value) {
+        is SearchUiState.Success -> {
+            // println("DEBUG_UI: 현재 UI 상태에서 검색 결과 개수: ${state.searchResults.size}, 마감된 의뢰 포함: ${state.includeExpired}")
+            state.searchResults
+        }
+        else -> {
+            // println("DEBUG_UI: UI 상태가 Success가 아님: ${uiState.value::class.simpleName}")
+            emptyList()
+        }
+    }
+    
     // 정렬된 검색 결과
-    val sortedResults = remember(searchResults, sortType) {
+    val sortedResults = remember(currentSearchResults, sortType) {
         when (sortType) {
-            SortType.LOWEST_PRICE_FIRST -> searchResults.sortedBy { it.reward }
-            SortType.HIGHEST_PRICE_FIRST -> searchResults.sortedByDescending { it.reward }
-            SortType.LATEST -> searchResults // 최신순은 이미 정렬되어 있다고 가정
-            SortType.MOST_POPULAR -> searchResults.sortedByDescending { it.reward } // 인기순은 일단 높은 가격순으로 대체
-            // 또는 else -> searchResults 로 처리 가능
+            SortType.LOWEST_PRICE_FIRST -> currentSearchResults.sortedBy { it.reward }
+            SortType.HIGHEST_PRICE_FIRST -> currentSearchResults.sortedByDescending { it.reward }
+            SortType.LATEST -> currentSearchResults // 최신순은 이미 정렬되어 있다고 가정
+            SortType.MOST_POPULAR -> currentSearchResults.sortedByDescending { it.reward } // 인기순은 일단 높은 가격순으로 대체
+            // 또는 else -> currentSearchResults 로 처리 가능
         }
     }
     
@@ -136,11 +149,12 @@ fun SearchResultView(
         // 검색 필터 영역
         SearchResultFilterBar(
             state = uiState.value,
-            onFilterClick = { showBottomSheet = true }
+            onFilterClick = { showBottomSheet = true },
+            viewModel = viewModel
         )
         
         // 검색 결과 목록
-        if (searchResults.isEmpty()) {
+        if (currentSearchResults.isEmpty()) {
             Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center
@@ -245,64 +259,91 @@ fun SearchResultView(
 /**
  * 검색 결과 필터 바
  */
+@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun SearchResultFilterBar(
     state: SearchUiState,
-    onFilterClick: () -> Unit
+    onFilterClick: () -> Unit,
+    viewModel: SearchViewModel
 ) {
-    // UI 상태 로그 추가
-    println("SearchResultFilterBar: 상태 타입 = ${state::class.simpleName}")
+    // UI 상태 로그 (필요시에만 활성화)
+    // println("SearchResultFilterBar: 상태 타입 = ${state::class.simpleName}")
     
-    if (state is SearchUiState.Success) {
-        println("SearchResultFilterBar: Success 상태 - 검색어: '${state.searchQuery}', 카테고리: ${state.selectedCategory ?: "전체"}, 지역: ${state.selectedRegion ?: "전체"}")
-    }
+    // if (state is SearchUiState.Success) {
+    //     println("SearchResultFilterBar: Success 상태 - 검색어: '${state.searchQuery}', 카테고리: ${state.selectedCategory ?: "전체"}, 지역: ${state.selectedRegion ?: "전체"}, 마감된 의뢰 포함: ${state.includeExpired}")
+    // }
     
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        // 왼쪽에 필터 칩들을 묶는 Row
+    Column(modifier = Modifier.fillMaxWidth()) {
+        // 기존 필터 칩들과 정렬 필터
         Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.weight(1f)
+            horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            if (state is SearchUiState.Success) {
-                // 검색어 표시 (없으면 "모든 검색어"로 표시)
-                FilterChip(
-                    label = if (state.searchQuery.isNotEmpty()) state.searchQuery else "모든 검색어",
-                    onClick = { }
-                )
+            // 왼쪽에 필터 칩들을 묶는 Row
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.weight(1f)
+            ) {
+                if (state is SearchUiState.Success) {
+                    // 검색어 표시 (없으면 "모든 검색어"로 표시)
+                    FilterChip(
+                        label = if (state.searchQuery.isNotEmpty()) state.searchQuery else "모든 검색어",
+                        onClick = { }
+                    )
+                    
+                    Spacer(modifier = Modifier.width(8.dp))
+                    
+                    // 선택된 카테고리 표시 (null이면 "전체 카테고리"로 표시)
+                    FilterChip(
+                        label = state.selectedCategory ?: "전체 카테고리",
+                        onClick = { }
+                    )
+                    
+                    Spacer(modifier = Modifier.width(8.dp))
+                    
+                    // 선택된 지역 표시 (null이면 "전체 지역"으로 표시)
+                    FilterChip(
+                        label = state.selectedRegion ?: "전체 지역",
+                        onClick = { }
+                    )
+                }
+            }
                 
-                Spacer(modifier = Modifier.width(8.dp))
-                
-                // 선택된 카테고리 표시 (null이면 "전체 카테고리"로 표시)
-                FilterChip(
-                    label = state.selectedCategory ?: "전체 카테고리",
-                    onClick = { }
-                )
-                
-                Spacer(modifier = Modifier.width(8.dp))
-                
-                // 선택된 지역 표시 (null이면 "전체 지역"으로 표시)
-                FilterChip(
-                    label = state.selectedRegion ?: "전체 지역",
-                    onClick = { }
+            // 정렬 방식 필터 아이콘 (오른쪽 끝에 배치)
+            IconButton(
+                onClick = onFilterClick
+            ) {
+                Icon(
+                    imageVector = Icons.Default.FilterList,
+                    contentDescription = "정렬 필터",
+                    tint = Color.Gray
                 )
             }
         }
-            
-        // 정렬 방식 필터 아이콘 (오른쪽 끝에 배치)
-        IconButton(
-            onClick = onFilterClick
-        ) {
-            Icon(
-                imageVector = Icons.Default.FilterList,
-                contentDescription = "정렬 필터",
-                tint = Color.Gray
-            )
+        
+        // 마감된 의뢰 포함 토글
+        if (state is SearchUiState.Success) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 4.dp)
+                    .clickable { viewModel.toggleIncludeExpired() },
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Checkbox(
+                    checked = state.includeExpired,
+                    onCheckedChange = { viewModel.toggleIncludeExpired() }
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "마감된 의뢰 포함",
+                    fontSize = 14.sp,
+                    color = Color.Gray
+                )
+            }
         }
     }
 }

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/search/SearchUiState.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/search/SearchUiState.kt
@@ -30,7 +30,8 @@ sealed class SearchUiState {
         val searchResults: List<SearchResult>,
         val recentSearches: List<String> = emptyList(),
         val recommendedSearches: List<String> = emptyList(),
-        val sortType: SortType = SortType.LATEST
+        val sortType: SortType = SortType.LATEST,
+        val includeExpired: Boolean = false // 마감된 의뢰 포함 여부
     ) : SearchUiState()
     
     /**

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/search/SearchView.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/search/SearchView.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.navigation.NavController
 import kotlinx.coroutines.launch
+import androidx.compose.runtime.LaunchedEffect
 import project.graduation.crowd_sourcing.presentation.ui.navigation.Screen
 import project.graduation.crowd_sourcing.presentation.ui.screen.search.component.SearchInputSection
 import project.graduation.crowd_sourcing.presentation.ui.screen.search.component.SelectedFiltersSection
@@ -57,6 +58,12 @@ fun SearchView(
     
     // 화면 콘텐츠 표시 여부를 제어하는 상태
     val showContent = remember { mutableStateOf(true) }
+    
+    // 초기 데이터 로딩 (검색 화면에서만 실행)
+    LaunchedEffect(Unit) {
+        println("DEBUG_SEARCHVIEW: SearchView 초기 데이터 로딩 시작")
+        viewModel.loadInitialData()
+    }
     
     // 화면 생명주기에 따라 콘텐츠 관리
     DisposableEffect(lifecycleOwner) {

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/search/SearchViewModel.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/search/SearchViewModel.kt
@@ -179,13 +179,13 @@ class SearchViewModel @Inject constructor(
         // 마감 시간이 이미 지난 경우
         if (now.isAfter(deadline)) {
             println("DEBUG_TIME: 마감 시간이 이미 지났습니다.")
-            return SearchResult(
-                id = commissionEntity.commission,
-                title = commissionEntity.commission,
-                place = "",
-                remainingDays = 0, // 시간이 지났음을 표시하는 특별 값 (0)
-                reward = commissionEntity.commissionpoint
-            )
+                    return SearchResult(
+            id = commissionEntity.commissionId.toString(),
+            title = commissionEntity.commission,
+            place = "",
+            remainingDays = 0, // 시간이 지났음을 표시하는 특별 값 (0)
+            reward = commissionEntity.commissionpoint
+        )
         }
         
         // 남은 시간에 따른 표시 방식 결정
@@ -210,7 +210,7 @@ class SearchViewModel @Inject constructor(
         println("DEBUG_TIME: 최종 표시 값: $remainingTime (${if (isHourFormat) "시간" else "일"} 단위)")
         
         return SearchResult(
-            id = commissionEntity.commission,
+            id = commissionEntity.commissionId.toString(),
             title = commissionEntity.commission,
             place = "",
             remainingDays = remainingTime, // 음수면 시간 단위, 양수면 일 단위

--- a/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/search/SearchViewModel.kt
+++ b/presentation/src/main/java/project/graduation/crowd_sourcing/presentation/ui/screen/search/SearchViewModel.kt
@@ -38,17 +38,26 @@ class SearchViewModel @Inject constructor(
 
     // 현재 진행 중인 검색 작업을 취소하기 위한 Job
     private var searchJob: Job? = null
+    
 
-    init {
-        loadInitialData()
-    }
+
+    // init 블록 제거 - SearchResultView에서는 초기 로딩이 필요하지 않음
 
     /**
      * 초기 데이터를 로드하여 상태를 설정
+     * 검색 화면에서만 호출되어야 함
      */
-    private fun loadInitialData() {
+    fun loadInitialData() {
+        // 이미 Success 상태이고 데이터가 있으면 로드를 건너뜀
+        val currentState = _uiState.value
+        if (currentState is SearchUiState.Success) {
+            println("DEBUG_INIT: 이미 Success 상태로 초기 로드를 건너뜀")
+            return
+        }
+        
         viewModelScope.launch {
             try {
+                println("DEBUG_REPO: 초기 검색 데이터 로드 시작")
                 val searchHome = getSearchHomeInitDataUseCase()
                 
                 // 지역과 카테고리 목록에 "전체" 옵션 추가
@@ -69,6 +78,9 @@ class SearchViewModel @Inject constructor(
                     recommendedSearches = searchHome.recommendedKeywords
                 )
             } catch (e: Exception) {
+                println("DEBUG_REPO: 초기 검색 데이터 예외 발생 - ${e::class.simpleName}: ${e.message}")
+                e.printStackTrace()
+                
                 // 오류 발생 시 기본 데이터로 초기화
                 val defaultCategories = listOf("전체", "과자/스낵", "라면/면류", "통조림/캔", "유제품", 
                                       "냉동식품", "즉석식품", "소스/양념", "음료/커피", "쌀/잡곡")
@@ -132,23 +144,47 @@ class SearchViewModel @Inject constructor(
             }
             
             // Domain Commission 객체를 UI SearchResult 객체로 변환
-            val searchResults = commissions.map { commission -> 
+            val allSearchResults = commissions.map { commission -> 
                 convertCommissionToSearchResult(commission)
             }
             
+            // 마감된 의뢰 필터링 적용
+            val currentState = _uiState.value as? SearchUiState.Success
+            val includeExpired = currentState?.includeExpired ?: false
+            
+            println("DEBUG_FILTER: includeExpired 값: $includeExpired")
+            
+            val filteredSearchResults = if (includeExpired) {
+                println("DEBUG_FILTER: 마감된 의뢰 포함 모드 - 모든 결과 표시")
+                allSearchResults
+            } else {
+                println("DEBUG_FILTER: 마감된 의뢰 제외 모드 - remainingDays != 0 필터링 적용")
+                val filtered = allSearchResults.filter { it.remainingDays != 0 }
+                println("DEBUG_FILTER: 필터링 전 ${allSearchResults.size}개 -> 필터링 후 ${filtered.size}개")
+                // 마감된 의뢰들 로그
+                val expiredItems = allSearchResults.filter { it.remainingDays == 0 }
+                println("DEBUG_FILTER: 제외된 마감 의뢰 ${expiredItems.size}개:")
+                expiredItems.forEachIndexed { index, item ->
+                    println("DEBUG_FILTER: 제외[${index}] - id: ${item.id}, title: ${item.title}, remainingDays: ${item.remainingDays}")
+                }
+                filtered
+            }
+            
+            println("DEBUG_SEARCH: 전체 검색 결과: ${allSearchResults.size}개, 필터링 후: ${filteredSearchResults.size}개 (마감된 의뢰 포함: $includeExpired)")
+            
             // 변환된 SearchResult 로그 출력
-            searchResults.forEachIndexed { index, result ->
+            filteredSearchResults.forEachIndexed { index, result ->
                 println("DEBUG_SEARCH: SearchResult[$index] - id: '${result.id}', title: '${result.title}', reward: ${result.reward}, remainingDays: ${result.remainingDays}")
             }
             
             // UI 상태 업데이트
             updateUiState { state ->
-                state.copy(searchResults = searchResults)
+                state.copy(searchResults = filteredSearchResults)
             }
             
-            println("DEBUG_SEARCH: 검색 결과 UI 상태 업데이트 완료 - 결과 개수: ${searchResults.size}")
+            println("DEBUG_SEARCH: 검색 결과 UI 상태 업데이트 완료 - 결과 개수: ${filteredSearchResults.size}")
             
-            return searchResults
+            return filteredSearchResults
         } catch (e: Exception) {
             println("DEBUG_SEARCH: 검색 API 호출 중 오류 발생 - ${e.message}")
             e.printStackTrace()
@@ -272,6 +308,24 @@ class SearchViewModel @Inject constructor(
     }
 
     /**
+     * 마감된 의뢰 포함 여부 토글
+     */
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun toggleIncludeExpired() {
+        val currentState = _uiState.value as? SearchUiState.Success ?: return
+        val newIncludeExpired = !currentState.includeExpired
+        
+        updateUiState { it.copy(includeExpired = newIncludeExpired) }
+        
+        // 즉시 현재 검색 결과에 필터링 적용
+        viewModelScope.launch {
+            performSearch()
+        }
+        
+        println("DEBUG_SEARCH: 마감된 의뢰 포함 설정 변경: $newIncludeExpired")
+    }
+
+    /**
      * 최근 검색어 목록에 검색어 추가
      */
     private fun addToRecentSearches(query: String) {
@@ -318,14 +372,35 @@ class SearchViewModel @Inject constructor(
         selectedCategory: String?,
         selectedRegion: String?
     ) {
-        updateUiState {
-            it.copy(
-                searchResults = searchResults,
-                searchQuery = searchQuery,
-                selectedCategory = selectedCategory,
-                selectedRegion = selectedRegion
-            )
+        
+        // 기본 카테고리와 지역 목록 설정
+        val defaultCategories = listOf("전체", "과자/스낵", "라면/면류", "통조림/캔", "유제품", 
+                                      "냉동식품", "즉석식품", "소스/양념", "음료/커피", "쌀/잡곡")
+        val defaultRegions = listOf("전체", "동대문구", "강남구", "서초구", "종로구", "용산구")
+        
+        // 기본적으로 마감된 의뢰는 포함하지 않으므로 필터링 적용
+        val includeExpired = false
+        val filteredSearchResults = if (includeExpired) {
+            searchResults
+        } else {
+            searchResults.filter { it.remainingDays != 0 } // remainingDays가 0이면 마감된 것
         }
+        
+        println("DEBUG_UPDATE_STATE: 받은 검색 결과: ${searchResults.size}개, 필터링 후: ${filteredSearchResults.size}개 (includeExpired: $includeExpired)")
+        
+        _uiState.value = SearchUiState.Success(
+            searchQuery = searchQuery,
+            categories = defaultCategories,
+            selectedCategory = selectedCategory,
+            regions = defaultRegions,
+            selectedRegion = selectedRegion,
+            searchResults = filteredSearchResults,
+            recentSearches = emptyList(),
+            recommendedSearches = emptyList(),
+            includeExpired = includeExpired
+        )
+        
+        println("DEBUG_UPDATE_STATE: 상태 업데이트 완료 - 검색어: '$searchQuery', 카테고리: ${selectedCategory ?: "전체"}, 지역: ${selectedRegion ?: "전체"}, 결과 개수: ${filteredSearchResults.size}, includeExpired: $includeExpired")
     }
 
     /**


### PR DESCRIPTION
# *📌 Issue*
- closed #6
- closed #27
- closed #42

# *⛳️ Work Description*



### 🎨 UI 구현

#### ▸ 작업 수락 화면 UI 구현 및 네비게이션 설정 (`feat/#50`)
- 수락 버튼 클릭 시 바로 포그라운드 서비스(Alarm Service: Alarm API연결)와 연결되도록 기본 작업
- Home view에서 마트 핀포인트 클릭하여 의뢰 클릭 시, 
Home view 검색 창에서 마트 선택 후 할당된 의뢰 클릭 시, 
Search view에서 검색 결과 의뢰 클릭 시 이동되도록 설정

#### ▸ Home View 내 현재 의뢰 개수 제한 및 전체 보기 페이지 생성 (`feat/#50`)
- `현재 의뢰` 최대 **2개**만 노출되도록 제한
- Home View에서는 몇 개의 `현재 의뢰`가 있는지만 알려주도록 함
- '전체 보기' 버튼 클릭 시 새로운 페이지로 이동하여 전체 `현재 의뢰` 리스트 제공

#### ▸ 화면별 크기 조정 및 스크롤바 추가 (`design/#50`)
- map의 크기를 동적으로 기기마다 조절하도록 함 (200px - 320px)
- 기기별로 화면 크기가 달라 스크롤 바 도입

---

### 🔍 기능 개선 및 추가

#### ▸ Search API 연동: 의뢰 상세 조회 기능 추가 및 UseCase 생성 (`feat/#50`)
- Service로 api연결 및 usecase 생성
- ID 기준으로 의뢰 상세 내용 반환되도록 함

#### ▸ Search View 마감시간 필터링 (`refactor/#50`)
- 현재 시간 기준으로 마감된 의뢰는 기본적으로 노출되지 않도록 필터 처리
- 별도의 토글을 넣어서 마감된 의뢰를 포함하여 볼 수 있도록 처리

#### ▸ Alarm API 연동 및 작업 수락 UseCase 연결 (`feat/#50`)
- Foreground 서비스 기반 작업 알림 기능 연결
- 의뢰 수락 usecase와 연결하여 `작업 수락` 페이지에서 작업 수락 버튼 클릭 시
해당 의뢰에 대해 현재 사용자가 의뢰를 수락하도록 설정

---

### 🛠️ 버그 수정

#### ▸ Commission Entity ID 처리 오류 수정 (`fix/#50`)
- Entity에 잘못 매핑된 ID 값 수정
- 정상 동작하도록 Repository 및 UseCase 연결

#### ▸ 기존 Service 반환 방식 오류 수정 (`fix/#50`)
- Response<String> 타입으로 받으니 제대로 파싱 못하는 오류가 생김
- Response<ResponseBody>로 받도록 수정


# *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->
### 🖼 작업 수락 화면  
- 해당 의뢰에 대해 클릭 시
<img src="https://github.com/user-attachments/assets/68765717-4cec-41f0-99be-2219da9132ad" width="320" />

- 작업 수락 화면 (지도에 좌표로 표시하는 부분
<img src="https://github.com/user-attachments/assets/fd8282b3-6293-4c45-ae99-79a8b290d719" width="320" />

- 작업 수락 버튼 클릭시 (테스트 계정 : test1, 음료수 진열 작업 수락)
<img src="https://github.com/user-attachments/assets/a15f9f2b-5221-41bd-b020-1181edcc6823" width="320" />

- 작업 수락 버튼 클릭 후 UI
<img src="https://github.com/user-attachments/assets/2faff7b5-e081-4957-b119-320ae5a34a01" width="320" />

- 작업 수락 후 test1 계정의 수행중인 의뢰 확인 ( Worker API의 /api/v1/worker/workongoing : 진행중인 작업 목록 조회  사용)
<img src="https://github.com/user-attachments/assets/d89fd3c0-d56e-496c-82c1-045561c00201" width="320" />
> 정상적으로 test1에 `음료수 진열(id:27)` 의뢰가 추가된 것을 확인

### 🖼 홈 화면 - 전체 보기 버튼 추가  및 현재의뢰 보이는 개수 제한
<img src="https://github.com/user-attachments/assets/ada7a60f-734c-4d3d-8670-d7bcd623e6f9" width="320" />

### 🖼 홈 화면 - 현재 의뢰 전체보기 페이지
<img src="https://github.com/user-attachments/assets/ab4f4031-12a4-4e7f-be7b-88840b100895" width="320" />

### 🖼 검색 화면 - 마감된 의뢰 필터링 추가 (default : 마감기한 지난 의뢰는 보이지 않도록 설정)
- 기본 검색 화면
<img src="https://github.com/user-attachments/assets/a95f3009-fc04-40ff-98c2-5295be0a5f26" width="320" />

- 마감된 의뢰 포함하여 보기
<img src="https://github.com/user-attachments/assets/e1ca3a16-4ab9-4066-84bb-b0510215cbdf" width="320" />





## *📢 To Reviewers*
- 기능적으로는 전체 구현 완료 상태이며, 일부 UI는 추후 개선 예정입니다.
- 확인해보시고 수정이 필요한 부분이나 궁금한 점이 있으시면 언제든지 편하게 연락 부탁드립니다.

---

### 🛠 이후 작업 예정

1. **작업 수락 페이지 UI 개선**
   - 상단 지도 컴포넌트 + 하단 수락 버튼은 고정
   - 중간 의뢰 정보 영역만 스크롤 가능하도록 수정 예정

2. **지도 위치 고정 현상 개선 예정**
   - 현재 지도에 위치가 고정되어 있음
   - `MartSearch API`를 통해 실제 마트 위치를 반영하도록 개선 예정

3. **참여 인원 수 표시 추가**
   - 현재는 최대 인원 수만 표시됨
   - 백엔드에서 수락한 인원 수도 응답하도록 수정되었으며, 해당 내용 바로 반영 예정

4. **추천 의뢰 로직 개선 (Home View)**
   - 현재 더미데이터로 구성
   - 사용자 위치 기반으로 반경 내 마트 검색 → 의뢰가 있는 마트만 필터링
   - 가까운 순으로 각 마트당 2개씩 추천 (동일 마트 내 여러 개일 경우 랜덤 추출)

5. **마트 마커 색상 구분 적용 예정**
   - 지도에 마트 위치를 마커로 표시 중
   - 의뢰가 없는 마트는 다른 색상으로 표현하여 시각적 구분 예정

<!-- PR 제목 형식: [FEATURE/#이슈번호] 작업 주제 -->

