### PR TITLE
[Chore/#52] Naver maps compose SDK 업데이트

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-06-22T22:06:11.897765200Z">
+        <DropdownSelection timestamp="2025-06-24T05:06:18.903516300Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\kimta\.android\avd\Pixel_77.avd" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=R39M200LRZV" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,4 @@
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -39,6 +40,11 @@ android {
     }
     buildFeatures {
         compose = true
+    }
+    packaging  {
+        resources {
+            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
+        }
     }
 }
 
@@ -83,7 +89,7 @@ dependencies {
 
     // 네이버 지도 SDK
     implementation("com.naver.maps:map-sdk:3.16.2")
-    implementation("io.github.fornewid:naver-map-compose:1.7.3")
+    implementation("io.github.fornewid:naver-map-compose:1.8.2")
     implementation("io.github.fornewid:naver-map-location:21.0.2")
     // Google Maps
     implementation("com.google.maps.android:maps-compose:2.11.4")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
             android:value="@integer/google_play_services_version" />
 
         <meta-data
-            android:name="com.naver.maps.map.CLIENT_ID"
+            android:name="com.naver.maps.map.NCP_KEY_ID"
             android:value="@string/naver_client_id"/>
 
         <activity


### PR DESCRIPTION
## *📌 Issue*
- closed #52 
<!-- closed를 붙이면 해당 이슈가 PR과 함께 자동으로 close -->

## *⛳️ Work Description*
1. Naver Maps Compose SDK 버전 업그레이드
> Naver maps compose전용 sdk의 버전을 1.7.3 -> 1.8.2로 업그레이드 (AI NAVER API -> MAPS API로 마이그레이션)

2. AndroidManifest key 이름 변경 확인
> 기존 "com.naver.maps.map.CLIENT_ID" -> "com.naver.maps.map.NCP_KEY_ID"로 변경
> key는 별도 전달

3. 앱 실행 및 기존 기능 정상 작동 테스트


## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->
- 변경 후 "홈 화면" 과 "의뢰 작성 화면"에서 Naver map 컴포넌트 정상작동 확인
<img src="https://github.com/user-attachments/assets/cd396868-95ca-46b6-b9ce-0d79a8aeb579" width=270 />
<img src="https://github.com/user-attachments/assets/1dde8284-2f0c-42d2-8173-4430dfd05353" width=270 />


## *📢 To Reviewers*
- 테스팅 완료하여 정상작동 확인했지만, 혹시 따른 오류 발생할 시 알려주시면 감사합니다
- 기존에 다른 서비스로 변경하면서 라이브러리간 리소스 중복으로 인해 오류가 발생했었습니다
( build.gradle에 packaging.resources.excludes로 해당 중복 리소스에 대하여 충돌 오류 해결함)
이와 비슷하게 오류가 발생하면 빠르게 알려주시면 감사하겠습니다

- 해당 PR이 머지되면 사전에 알려드린 key로 변경해주셔야 합니다

<!-- PR 제목 형식: [FEATURE/#이슈번호] 작업 주제 -->
